### PR TITLE
gdrdrv: fix use-after-free of variable mr in case of error

### DIFF
--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -418,8 +418,8 @@ out:
     }
 
     if (ret && mr) {
-        kfree(mr);
         memset(mr, 0, sizeof(*mr));
+        kfree(mr);
         mr = NULL;
     }
 


### PR DESCRIPTION
This used to crash the kernel when something went wrong. Maybe the `memset` should be done before freeing the object, but anyway I'm not sure why this should be done.