### PR TITLE
Use unroll8 and unroll4 open-coded memcpy functions on ppc

### DIFF
--- a/copybw.cpp
+++ b/copybw.cpp
@@ -163,8 +163,8 @@ main(int argc, char *argv[])
         uint32_t *buf_ptr = (uint32_t *)((char *)bar_ptr + off);
         OUT << "user-space pointer:" << buf_ptr << endl;
 
-        // copy to BAR benchmark
-        cout << "BAR writing test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_write_iters << endl;
+        // copy to GPU benchmark
+        cout << "writing test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_write_iters << endl;
         struct timespec beg, end;
         clock_gettime(MYCLOCK, &beg);
         for (int iter=0; iter<num_write_iters; ++iter)
@@ -177,13 +177,13 @@ main(int argc, char *argv[])
             double dt_ms = (end.tv_nsec-beg.tv_nsec)/1000000.0 + (end.tv_sec-beg.tv_sec)*1000.0;
             double Bps = byte_count / dt_ms * 1e3;
             woMBps = Bps / 1024.0 / 1024.0;
-            cout << "BAR1 write BW: " << woMBps << "MB/s" << endl;
+            cout << "write BW: " << woMBps << "MB/s" << endl;
         }
 
         compare_buf(init_buf, buf_ptr + copy_offset/4, copy_size);
 
         // copy from BAR benchmark
-        cout << "BAR reading test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_read_iters << endl;
+        cout << "reading test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_read_iters << endl;
         clock_gettime(MYCLOCK, &beg);
         for (int iter=0; iter<num_read_iters; ++iter)
             gdr_copy_from_bar(init_buf, buf_ptr + copy_offset/4, copy_size);
@@ -195,7 +195,7 @@ main(int argc, char *argv[])
             double dt_ms = (end.tv_nsec-beg.tv_nsec)/1000000.0 + (end.tv_sec-beg.tv_sec)*1000.0;
             double Bps = byte_count / dt_ms * 1e3;
             roMBps = Bps / 1024.0 / 1024.0;
-            cout << "BAR1 read BW: " << roMBps << "MB/s" << endl;
+            cout << "read BW: " << roMBps << "MB/s" << endl;
         }
 
         OUT << "unmapping buffer" << endl;

--- a/gdrapi.c
+++ b/gdrapi.c
@@ -344,10 +344,10 @@ static void gdr_init_cpu_flags()
 
 // note: more than one implementation may be compiled in
 
-static void unroll8_memcpy(void *map_d_ptr, const void *h_ptr, size_t size)
+static void unroll8_memcpy(void *dst, const void *src, size_t size)
 {
-    const uint64_t *r = (const uint64_t *)h_ptr;
-    uint64_t *w = (uint64_t *)map_d_ptr;
+    const uint64_t *r = (const uint64_t *)src;
+    uint64_t *w = (uint64_t *)dst;
     size_t nw = size / sizeof(*r);
     assert(size % sizeof(*r) == 0);
 
@@ -381,10 +381,10 @@ static void unroll8_memcpy(void *map_d_ptr, const void *h_ptr, size_t size)
     }
 }
 
-static void unroll4_memcpy(void *map_d_ptr, const void *h_ptr, size_t size)
+static void unroll4_memcpy(void *dst, const void *src, size_t size)
 {
-    const uint32_t *r = (const uint32_t *)h_ptr;
-    uint32_t *w = (uint32_t *)map_d_ptr;
+    const uint32_t *r = (const uint32_t *)src;
+    uint32_t *w = (uint32_t *)dst;
     size_t nw = size / sizeof(*r);
     assert(size % sizeof(*r) == 0);
 

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -27,7 +27,7 @@
 #include <stddef.h>
 
 #define GDR_API_MAJOR_VERSION    1
-#define GDR_API_MINOR_VERSION    2
+#define GDR_API_MINOR_VERSION    4
 #define GDR_API_VERSION          ((GDR_API_MAJOR_VERSION << 16) | GDR_API_MINOR_VERSION)
 
 

--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -9,7 +9,7 @@
 
 
 Name:           gdrcopy
-Version:        1.3
+Version:        1.4
 Release:        %{_release}%{?dist}
 Summary:        GDRcopy library and companion kernel-mode driver    
 Group:          System Environment/Libraries


### PR DESCRIPTION
with this version I get:
$ ./copybw.sh 
+ GDRCOPY_ENABLE_LOGGING=1
+ GDRCOPY_LOG_LEVEL=0
+ LD_LIBRARY_PATH=/home/user/drossetti/Coral/gdrcopy:/home/user/drossetti/Coral/gdrcopy:
+ numactl -N 0 -l ./copybw -d 0 -s 262144 -o 0 -c 262144
GPU id:0 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 4 device: 0
GPU id:1 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 5 device: 0
GPU id:2 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 3 device: 0
GPU id:3 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 4 device: 0
selecting device 0
testing size: 262144
rounded size: 262144
device ptr: 7fff59600000
bar_ptr: 0x7fff78350000
info.va: 7fff59600000
info.mapped_size: 262144
info.page_size: 65536
page offset: 0
user-space pointer:0x7fff78350000
writing test, size=262144 offset=0 num_iters=10000
DBG:  using unroll4_memcpy for gdr_copy_to_bar
write BW: 1954.22MB/s
reading test, size=262144 offset=0 num_iters=100
DBG:  using unroll8_memcpy for gdr_copy_from_bar
read BW: 21.3662MB/s
unmapping buffer
unpinning buffer
closing gdrdrv

fixes #29 