### PR TITLE
Use cached CPU mappings on POWER9

### DIFF
--- a/basic.cpp
+++ b/basic.cpp
@@ -58,14 +58,15 @@ int main(int argc, char *argv[])
     gdr_t g = gdr_open();
     ASSERT_NEQ(g, (void*)0);
 
-    gdr_mh_t mh;
+    gdr_mh_t mh = {0};
+    if (mh == null_mh) puts("miao");
     BEGIN_CHECK {
         CUdeviceptr d_ptr = d_A;
 
         // tokens are optional in CUDA 6.0
         // wave out the test if GPUDirectRDMA is not enabled
         BREAK_IF_NEQ(gdr_pin_buffer(g, d_ptr, size, 0, 0, &mh), 0);
-        ASSERT_NEQ(mh, 0U);
+        ASSERT_NEQ(mh, null_mh);
         ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);
     } END_CHECK;
     ASSERT_EQ(gdr_close(g), 0);

--- a/basic.cpp
+++ b/basic.cpp
@@ -59,7 +59,8 @@ int main(int argc, char *argv[])
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = {0};
-    if (mh == null_mh) puts("miao");
+    ASSERT(mh == null_mh);
+
     BEGIN_CHECK {
         CUdeviceptr d_ptr = d_A;
 

--- a/common.hpp
+++ b/common.hpp
@@ -63,7 +63,7 @@ static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
 {
     int diff = 0;
     if (size % 4 != 0U) {
-        printf("warning: buffer size %d is not dword aligned, ignoring trailing bytes\n", size);
+        printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
         size -= (size % 4);
     }
     unsigned ndwords = size/sizeof(uint32_t);

--- a/common.hpp
+++ b/common.hpp
@@ -46,9 +46,15 @@
             ASSERT(cudaSuccess == result);     \
         } while (0)
 
+static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
+    return a.h == b.h;
+}
+
+static const gdr_mh_t null_mh = {0};
+
 #define ASSERT_EQ(P, V) ASSERT((P) == (V))
 #define CHECK_EQ(P, V) ASSERT((P) == (V))
-#define ASSERT_NEQ(P, V) ASSERT((P) != (V))
+#define ASSERT_NEQ(P, V) ASSERT(!((P) == (V)))
 #define BREAK_IF_NEQ(P, V) if((P) != (V)) break
 #define BEGIN_CHECK do
 #define END_CHECK while(0)

--- a/common.hpp
+++ b/common.hpp
@@ -63,7 +63,7 @@ static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
 {
     int diff = 0;
     if (size % 4 != 0U) {
-        printf("warning: buffer size %d is not dword aligned, ignoring trailing bytes\n");
+        printf("warning: buffer size %d is not dword aligned, ignoring trailing bytes\n", size);
         size -= (size % 4);
     }
     unsigned ndwords = size/sizeof(uint32_t);

--- a/copybw.cpp
+++ b/copybw.cpp
@@ -170,7 +170,7 @@ main(int argc, char *argv[])
         struct timespec beg, end;
         clock_gettime(MYCLOCK, &beg);
         for (int iter=0; iter<num_write_iters; ++iter)
-            gdr_copy_to_bar(buf_ptr + copy_offset/4, init_buf, copy_size);
+            gdr_copy_to_mapping(mh, buf_ptr + copy_offset/4, init_buf, copy_size);
         clock_gettime(MYCLOCK, &end);
 
         double woMBps;
@@ -188,7 +188,7 @@ main(int argc, char *argv[])
         cout << "reading test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_read_iters << endl;
         clock_gettime(MYCLOCK, &beg);
         for (int iter=0; iter<num_read_iters; ++iter)
-            gdr_copy_from_bar(init_buf, buf_ptr + copy_offset/4, copy_size);
+            gdr_copy_from_mapping(mh, init_buf, buf_ptr + copy_offset/4, copy_size);
         clock_gettime(MYCLOCK, &end);
 
         double roMBps;

--- a/copybw.cpp
+++ b/copybw.cpp
@@ -144,9 +144,9 @@ main(int argc, char *argv[])
         BREAK_IF_NEQ(gdr_pin_buffer(g, d_A, size, 0, 0, &mh), 0);
         ASSERT_NEQ(mh, null_mh);
 
-        void *bar_ptr  = NULL;
-        ASSERT_EQ(gdr_map(g, mh, &bar_ptr, size), 0);
-        OUT << "bar_ptr: " << bar_ptr << endl;
+        void *map_d_ptr  = NULL;
+        ASSERT_EQ(gdr_map(g, mh, &map_d_ptr, size), 0);
+        OUT << "map_d_ptr: " << map_d_ptr << endl;
 
         gdr_info_t info;
         ASSERT_EQ(gdr_get_info(g, mh, &info), 0);
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
         int off = info.va - d_A;
         OUT << "page offset: " << off << endl;
 
-        uint32_t *buf_ptr = (uint32_t *)((char *)bar_ptr + off);
+        uint32_t *buf_ptr = (uint32_t *)((char *)map_d_ptr + off);
         OUT << "user-space pointer:" << buf_ptr << endl;
 
         // copy to GPU benchmark
@@ -184,7 +184,7 @@ main(int argc, char *argv[])
 
         compare_buf(init_buf, buf_ptr + copy_offset/4, copy_size);
 
-        // copy from BAR benchmark
+        // copy from GPU benchmark
         cout << "reading test, size=" << copy_size << " offset=" << copy_offset << " num_iters=" << num_read_iters << endl;
         clock_gettime(MYCLOCK, &beg);
         for (int iter=0; iter<num_read_iters; ++iter)
@@ -201,7 +201,7 @@ main(int argc, char *argv[])
         }
 
         OUT << "unmapping buffer" << endl;
-        ASSERT_EQ(gdr_unmap(g, mh, bar_ptr, size), 0);
+        ASSERT_EQ(gdr_unmap(g, mh, map_d_ptr, size), 0);
 
         OUT << "unpinning buffer" << endl;
         ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);

--- a/copybw.cpp
+++ b/copybw.cpp
@@ -142,7 +142,7 @@ main(int argc, char *argv[])
         // tokens are optional in CUDA 6.0
         // wave out the test if GPUDirectRDMA is not enabled
         BREAK_IF_NEQ(gdr_pin_buffer(g, d_A, size, 0, 0, &mh), 0);
-        ASSERT_NEQ(mh, 0U);
+        ASSERT_NEQ(mh, null_mh);
 
         void *bar_ptr  = NULL;
         ASSERT_EQ(gdr_map(g, mh, &bar_ptr, size), 0);

--- a/copybw.cpp
+++ b/copybw.cpp
@@ -153,6 +153,8 @@ main(int argc, char *argv[])
         OUT << "info.va: " << hex << info.va << dec << endl;
         OUT << "info.mapped_size: " << info.mapped_size << endl;
         OUT << "info.page_size: " << info.page_size << endl;
+        OUT << "info.mapped: " << info.mapped << endl;
+        OUT << "info.wc_mapping: " << info.wc_mapping << endl;
 
         // remember that mappings start on a 64KB boundary, so let's
         // calculate the offset from the head of the mapping to the

--- a/gdrapi.c
+++ b/gdrapi.c
@@ -496,7 +496,7 @@ int gdr_copy_to_bar(void *map_d_ptr, const void *h_ptr, size_t size)
             break;
         }
 
-        // on POWER, compiler memcpy is not optimal for MMIO
+        // on POWER, compiler/libc memcpy is not optimal for MMIO
         // 64bit stores are not better than 32bit ones, so we prefer the latter
         // NOTE: if preferred but not aligned, a better implementation would still try to
         // use byte sized stores to align map_d_ptr and h_ptr to next word
@@ -509,7 +509,7 @@ int gdr_copy_to_bar(void *map_d_ptr, const void *h_ptr, size_t size)
             unroll4_memcpy(map_d_ptr, h_ptr, size);
             break;
         } else {
-            gdr_dbgc(1, "using plain memcpy for gdr_copy_to_bar\n");
+            gdr_dbgc(1, "fallback to compiler/libc memcpy implementation of gdr_copy_to_bar\n");
             memcpy(map_d_ptr, h_ptr, size);
         }
 
@@ -556,9 +556,10 @@ int gdr_copy_from_bar(void *h_ptr, const void *map_d_ptr, size_t size)
             unroll4_memcpy(h_ptr, map_d_ptr, size);
             break;
         } else {
-            gdr_dbgc(1, "using plain memcpy for gdr_copy_from_bar\n");
+            gdr_dbgc(1, "fallback to compiler/libc memcpy implementation of gdr_copy_from_bar\n");
             memcpy(h_ptr, map_d_ptr, size);
         }
+
         // note: fencing is not needed because plain stores are used
         // if non-temporal stores were used on x86, a proper fence would be needed instead
         // wc_store_fence();

--- a/gdrapi.c
+++ b/gdrapi.c
@@ -248,9 +248,9 @@ int gdr_map(gdr_t g, gdr_mh_t handle, void **ptr_va, size_t size)
                 strerror(__errno), __errno, handle, rounded_size, (long long unsigned)magic_off);
         ret = __errno;
     }
-
-    *ptr_va = mmio;
-
+    if (!ret) {
+        *ptr_va = mmio;
+    }
     return ret;
 }
 

--- a/gdrapi.c
+++ b/gdrapi.c
@@ -223,6 +223,8 @@ int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info)
         info->page_size   = params.page_size;
         info->tm_cycles   = params.tm_cycles;
         info->cycles_per_ms = params.tsc_khz;
+        info->mapped      = params.mapped;
+        info->wc_mapping  = params.wc_mapping;
     }
     return ret;
 }

--- a/gdrapi.c
+++ b/gdrapi.c
@@ -101,11 +101,24 @@ static void gdr_msg(enum gdrcopy_msg_level lvl, const char* fmt, ...)
 #define gdr_warn(FMT, ARGS...) gdr_msg(GDRCOPY_MSG_WARN,  "WARN: " FMT, ## ARGS)
 #define gdr_err(FMT, ARGS...)  gdr_msg(GDRCOPY_MSG_ERROR, "ERR:  " FMT, ## ARGS)
 
+typedef struct { 
+    gdr_hnd_t handle;
+    unsigned mapped:1;
+    unsigned wc_mapping:1;
+} gdr_memh_t;
+
+static gdr_memh_t *to_memh(gdr_mh_t mh) {
+    return (gdr_memh_t *)mh.h;
+}
+
+static gdr_mh_t from_memh(gdr_memh_t *memh) {
+    gdr_mh_t mh;
+    mh.h = (unsigned long)memh;
+    return mh;
+}
+
 // check GDR HaNDle size
-
-COMPILE_TIME_ASSERT(sizeof(gdr_hnd_t)==sizeof(gdr_mh_t));
-
-
+//COMPILE_TIME_ASSERT(sizeof(gdr_hnd_t)==sizeof(gdr_mh_t));
 
 struct gdr {
     int fd;
@@ -153,6 +166,15 @@ int gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token,
     int ret = 0;
     int retcode;
 
+    if (!handle) {
+        return EINVAL;
+    }
+
+    gdr_memh_t *mh = calloc(1, sizeof(gdr_memh_t));
+    if (!mh) {
+        return ENOMEM;
+    }
+
     struct GDRDRV_IOC_PIN_BUFFER_PARAMS params;
     params.addr = addr;
     params.size = size;
@@ -164,9 +186,11 @@ int gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token,
     if (0 != retcode) {
         ret = errno;
         gdr_err("ioctl error (errno=%d)\n", ret);
+        goto err;
     }
-    *handle = params.handle;
-
+    mh->handle = params.handle;
+    *handle = from_memh(mh);
+ err:
     return ret;
 }
 
@@ -174,16 +198,16 @@ int gdr_unpin_buffer(gdr_t g, gdr_mh_t handle)
 {
     int ret = 0;
     int retcode;
+    gdr_memh_t *mh = to_memh(handle);
 
     struct GDRDRV_IOC_UNPIN_BUFFER_PARAMS params;
-    params.handle = handle;
-
+    params.handle = mh->handle;
     retcode = ioctl(g->fd, GDRDRV_IOC_UNPIN_BUFFER, &params);
     if (0 != retcode) {
         ret = errno;
         gdr_err("ioctl error (errno=%d)\n", ret);
     }
-
+    
     return ret;
 }
 
@@ -191,17 +215,17 @@ int gdr_get_callback_flag(gdr_t g, gdr_mh_t handle, int *flag)
 {
     int ret = 0;
     int retcode;
+    gdr_memh_t *mh = to_memh(handle);
 
     struct GDRDRV_IOC_GET_CB_FLAG_PARAMS params;
-    params.handle = handle;
-
+    params.handle = mh->handle;
     retcode = ioctl(g->fd, GDRDRV_IOC_GET_CB_FLAG, &params);
     if (0 != retcode) {
         ret = errno;
         gdr_err("ioctl error (errno=%d)\n", ret);
-    } else
+    } else {
         *flag = params.flag;
-
+    }
     return ret;
 }
 
@@ -209,9 +233,10 @@ int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info)
 {
     int ret = 0;
     int retcode;
+    gdr_memh_t *mh = to_memh(handle);
 
     struct GDRDRV_IOC_GET_INFO_PARAMS params;
-    params.handle = handle;
+    params.handle = mh->handle;
 
     retcode = ioctl(g->fd, GDRDRV_IOC_GET_INFO, &params);
     if (0 != retcode) {
@@ -233,26 +258,38 @@ int gdr_map(gdr_t g, gdr_mh_t handle, void **ptr_va, size_t size)
 {
     int ret = 0;
     gdr_info_t info = {0,};
+    gdr_memh_t *mh = to_memh(handle);
 
-    ret = gdr_get_info(g, handle, &info);
-    if (ret) {
-        return ret;
+    if (mh->mapped) {
+        gdr_err("mh is mapped already\n");
+        return EAGAIN;
     }
     size_t rounded_size = (size + PAGE_SIZE - 1) & PAGE_MASK;
-    off_t magic_off = (off_t)handle << PAGE_SHIFT;
-    void *mmio;
-
-    mmio = mmap(NULL, rounded_size, PROT_READ|PROT_WRITE, MAP_SHARED, g->fd, magic_off);
+    off_t magic_off = (off_t)mh->handle << PAGE_SHIFT;
+    void *mmio = mmap(NULL, rounded_size, PROT_READ|PROT_WRITE, MAP_SHARED, g->fd, magic_off);
     if (mmio == MAP_FAILED) {
         int __errno = errno;
         mmio = NULL;
         gdr_err("error %s(%d) while mapping handle %x, rounded_size=%zu offset=%llx\n",
                 strerror(__errno), __errno, handle, rounded_size, (long long unsigned)magic_off);
         ret = __errno;
+        goto err;
     }
-    if (!ret) {
-        *ptr_va = mmio;
+    *ptr_va = mmio;
+    ret = gdr_get_info(g, handle, &info);
+    if (ret) {
+        gdr_err("error %d from get_info, munmapping before exiting\n", ret);
+        munmap(mmio, rounded_size);
+        goto err;
     }
+    mh->mapped = info.mapped;
+    if (!mh->mapped) {
+        gdr_err("mh should have been mapped at this point\n");
+        abort();
+    }
+    mh->wc_mapping = info.wc_mapping;
+    gdr_dbg("wc_mapping=%d\n", mh->wc_mapping);
+ err:
     return ret;
 }
 
@@ -261,15 +298,23 @@ int gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size)
     int ret = 0;
     int retcode = 0;
     size_t rounded_size = (size + PAGE_SIZE - 1) & PAGE_MASK;
+    gdr_memh_t *mh = to_memh(handle);
 
+    if (!mh->mapped) {
+        gdr_err("mh is not mapped yet\n");
+        return EINVAL;
+    }
     retcode = munmap(va, rounded_size);
     if (-1 == retcode) {
         int __errno = errno;
         gdr_err("error %s(%d) while unmapping handle %x, rounded_size=%zu\n",
                 strerror(__errno), __errno, handle, rounded_size);
         ret = __errno;
+        goto err;
     }
-
+    mh->mapped = 0;
+    mh->wc_mapping = 0;
+ err:
     return ret;
 }
 

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -68,6 +68,7 @@ gdr_t gdr_open();
 // gdr_unmap on all mappings before calling gdr_close.
 int gdr_close(gdr_t g);
 
+// The handle to a GPU memory mapping
 typedef struct gdr_mh_s {
   unsigned long h;
 } gdr_mh_t;

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -68,7 +68,7 @@ gdr_t gdr_open();
 // gdr_unmap on all mappings before calling gdr_close.
 int gdr_close(gdr_t g);
 
-// The handle to a GPU memory mapping
+// The handle to a user-space GPU memory mapping
 typedef struct gdr_mh_s {
   unsigned long h;
 } gdr_mh_t;
@@ -99,8 +99,8 @@ struct gdr_info {
     uint32_t page_size;
     uint64_t tm_cycles;
     uint32_t cycles_per_ms;
-    uint32_t mapped;
-    uint32_t wc_mapping;
+    unsigned mapped:1;
+    unsigned wc_mapping:1;
 };
 typedef struct gdr_info gdr_info_t;
 int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info);
@@ -118,10 +118,10 @@ int gdr_map(gdr_t g, gdr_mh_t handle, void **va, size_t size);
 // First invoke gdr_unmap() then gdr_unpin_buffer().
 int gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size);
 
-// gpubar_ptr is a user-space virtual address, i.e. one returned by gdr_map()
-int gdr_copy_to_bar(void  *gpubar_ptr, const void *cpumem_ptr, size_t size);
-int gdr_copy_from_bar(void *cpumem_ptr, const void *gpubar_ptr, size_t size);
-
+// map_d_ptr is the user-space virtual address belonging to a mapping of a device memory buffer,
+// i.e. one returned by gdr_map()
+int gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, size_t size);
+int gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, size_t size);
 
 #ifdef __cplusplus
 }

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -68,9 +68,12 @@ gdr_t gdr_open();
 // gdr_unmap on all mappings before calling gdr_close.
 int gdr_close(gdr_t g);
 
+typedef struct gdr_mh_s {
+  unsigned long h;
+} gdr_mh_t;
+
 // Map device memory buffer on GPU BAR1, returning an handle.
 // Memory is still not accessible to user-space.
-typedef uint32_t gdr_mh_t;
 int gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle);
 
 // Unmap the handle. 

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -95,6 +95,8 @@ struct gdr_info {
     uint32_t page_size;
     uint64_t tm_cycles;
     uint32_t cycles_per_ms;
+    uint32_t mapped;
+    uint32_t wc_mapping;
 };
 typedef struct gdr_info gdr_info_t;
 int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info);

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -73,11 +73,11 @@ typedef struct gdr_mh_s {
   unsigned long h;
 } gdr_mh_t;
 
-// Map device memory buffer on GPU BAR1, returning an handle.
-// Memory is still not accessible to user-space.
+// Create a peer-to-peer mapping of the device memory buffer, returning an opaque handle.
+// Note that at this point the mapping is still not accessible to user-space.
 int gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle);
 
-// Unmap the handle. 
+// Destroys the peer-to-peer mapping and frees the handle.
 //
 // If there exists a corresponding user-space mapping, gdr_unmap should be
 // called before this one.
@@ -105,10 +105,9 @@ struct gdr_info {
 typedef struct gdr_info gdr_info_t;
 int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info);
 
-// create a user-space mapping for the BAR1 info, length is bar1->size
-// above.
+// Create a user-space mapping of the memory handle.
 //
-// WARNING: the BAR physical address will be aligned to the page size
+// WARNING: the address could be potentially aligned to the boundary of the page size
 // before being mapped in user-space, so the pointer returned might be
 // affected by an offset. gdr_get_info can be used to calculate that
 // offset.

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -790,7 +790,7 @@ static int __init gdrdrv_init(void)
     gdr_msg(KERN_INFO, "device registered with major number %d\n", gdrdrv_major);
     gdr_msg(KERN_INFO, "dbg traces %s, info traces %s", dbg_enabled ? "enabled" : "disabled", info_enabled ? "enabled" : "disabled");
 
-#if defined(CONFIG_PPC64)
+#if defined(CONFIG_PPC64) && defined(PVR_POWER9)
     if (pvr_version_is(PVR_POWER9)) {
         // Approximating CPU-GPU coherence with CPU model
         // This might break in the future

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -68,7 +68,14 @@ static inline int gdr_pfn_is_ram(unsigned long pfn)
 {
     // catch platforms, e.g. POWER8, POWER9 with GPUs not attached via NVLink,
     // where GPU memory is non-coherent
+#if 0
+    // unfortunately this module is MIT, and page_is_ram is GPL-only.
     return page_is_ram(pfn);
+#else
+    unsigned long start = pfn << PAGE_SHIFT;
+    unsigned long mask_47bits = (1UL<<47)-1;
+    return 0 == (start & ~mask_47bits);
+#endif
 }
 
 #else

--- a/gdrdrv/gdrdrv.h
+++ b/gdrdrv/gdrdrv.h
@@ -77,6 +77,8 @@ struct GDRDRV_IOC_GET_INFO_PARAMS
     __u32 page_size;
     __u32 tsc_khz;
     __u64 tm_cycles;
+    __u32 mapped;
+    __u32 wc_mapping;
 };
 
 #define GDRDRV_IOC_GET_INFO _IOWR(GDRDRV_IOCTL, 4, struct GDRDRV_IOC_GET_INFO_PARAMS *)

--- a/gdrdrv/nv-p2p-dummy.c
+++ b/gdrdrv/nv-p2p-dummy.c
@@ -92,6 +92,30 @@ int nvidia_p2p_free_page_table(struct nvidia_p2p_page_table *page_table)
 }
 EXPORT_SYMBOL(nvidia_p2p_free_page_table);
 
+int nvidia_p2p_get_rsync_registers(nvidia_p2p_rsync_reg_info_t **reg_info)
+{
+    return -EINVAL;
+}
+EXPORT_SYMBOL(nvidia_p2p_get_rsync_registers);
+
+void nvidia_p2p_put_rsync_registers(nvidia_p2p_rsync_reg_info_t *reg_info)
+{
+}
+EXPORT_SYMBOL(nvidia_p2p_put_rsync_registers);
+
+int nvidia_p2p_register_rsync_driver(nvidia_p2p_rsync_driver_t *driver,
+                                     void *data)
+{
+    return -EINVAL;
+}
+EXPORT_SYMBOL(nvidia_p2p_register_rsync_driver);
+
+void nvidia_p2p_unregister_rsync_driver(nvidia_p2p_rsync_driver_t *driver,
+                                        void *data)
+{
+}
+EXPORT_SYMBOL(nvidia_p2p_unregister_rsync_driver);
+
 static int __init nv_p2p_dummy_init(void)
 {
     return 0;

--- a/gdrdrv/nv-p2p-dummy.c
+++ b/gdrdrv/nv-p2p-dummy.c
@@ -92,30 +92,6 @@ int nvidia_p2p_free_page_table(struct nvidia_p2p_page_table *page_table)
 }
 EXPORT_SYMBOL(nvidia_p2p_free_page_table);
 
-int nvidia_p2p_get_rsync_registers(nvidia_p2p_rsync_reg_info_t **reg_info)
-{
-    return -EINVAL;
-}
-EXPORT_SYMBOL(nvidia_p2p_get_rsync_registers);
-
-void nvidia_p2p_put_rsync_registers(nvidia_p2p_rsync_reg_info_t *reg_info)
-{
-}
-EXPORT_SYMBOL(nvidia_p2p_put_rsync_registers);
-
-int nvidia_p2p_register_rsync_driver(nvidia_p2p_rsync_driver_t *driver,
-                                     void *data)
-{
-    return -EINVAL;
-}
-EXPORT_SYMBOL(nvidia_p2p_register_rsync_driver);
-
-void nvidia_p2p_unregister_rsync_driver(nvidia_p2p_rsync_driver_t *driver,
-                                        void *data)
-{
-}
-EXPORT_SYMBOL(nvidia_p2p_unregister_rsync_driver);
-
 static int __init nv_p2p_dummy_init(void)
 {
     return 0;

--- a/validate.cpp
+++ b/validate.cpp
@@ -72,16 +72,16 @@ int main(int argc, char *argv[])
         ASSERT_EQ(gdr_get_info(g, mh, &info), 0);
         ASSERT(!info.mapped);
 
-        void *bar_ptr  = NULL;
-        ASSERT_EQ(gdr_map(g, mh, &bar_ptr, size), 0);
-        //OUT << "bar_ptr: " << bar_ptr << endl;
+        void *map_d_ptr  = NULL;
+        ASSERT_EQ(gdr_map(g, mh, &map_d_ptr, size), 0);
+        //OUT << "map_d_ptr: " << map_d_ptr << endl;
 
         ASSERT_EQ(gdr_get_info(g, mh, &info), 0);
         ASSERT(info.mapped);
         int off = d_ptr - info.va;
         cout << "off: " << off << endl;
 
-        uint32_t *buf_ptr = (uint32_t *)((char *)bar_ptr + off);
+        uint32_t *buf_ptr = (uint32_t *)((char *)map_d_ptr + off);
         //OUT << "buf_ptr:" << buf_ptr << endl;
 
         printf("check 1: MMIO CPU initialization + read back via cuMemcpy D->H\n");
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size - extra_off), 0);
 
         printf("unampping\n");
-        ASSERT_EQ(gdr_unmap(g, mh, bar_ptr, size), 0);
+        ASSERT_EQ(gdr_unmap(g, mh, map_d_ptr, size), 0);
         printf("unpinning\n");
         ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);
     } END_CHECK;

--- a/validate.cpp
+++ b/validate.cpp
@@ -68,12 +68,16 @@ int main(int argc, char *argv[])
         BREAK_IF_NEQ(gdr_pin_buffer(g, d_ptr, size, 0, 0, &mh), 0);
         ASSERT_NEQ(mh, 0U);
 
+        gdr_info_t info;
+        ASSERT_EQ(gdr_get_info(g, mh, &info), 0);
+        ASSERT(!info.mapped);
+
         void *bar_ptr  = NULL;
         ASSERT_EQ(gdr_map(g, mh, &bar_ptr, size), 0);
         //OUT << "bar_ptr: " << bar_ptr << endl;
 
-        gdr_info_t info;
         ASSERT_EQ(gdr_get_info(g, mh, &info), 0);
+        ASSERT(info.mapped);
         int off = d_ptr - info.va;
         cout << "off: " << off << endl;
 

--- a/validate.cpp
+++ b/validate.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
         // tokens are optional in CUDA 6.0
         // wave out the test if GPUDirectRDMA is not enabled
         BREAK_IF_NEQ(gdr_pin_buffer(g, d_ptr, size, 0, 0, &mh), 0);
-        ASSERT_NEQ(mh, 0U);
+        ASSERT_NEQ(mh, null_mh);
 
         gdr_info_t info;
         ASSERT_EQ(gdr_get_info(g, mh, &info), 0);

--- a/validate.cpp
+++ b/validate.cpp
@@ -85,6 +85,7 @@ int main(int argc, char *argv[])
         //OUT << "buf_ptr:" << buf_ptr << endl;
 
         printf("check 1: MMIO CPU initialization + read back via cuMemcpy D->H\n");
+        memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
         init_hbuf_walking_bit(buf_ptr, size);
         //mmiowcwb();
         ASSERTDRV(cuMemcpyDtoH(copy_buf, d_ptr, size));
@@ -92,33 +93,37 @@ int main(int argc, char *argv[])
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size), 0);
         memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
-        printf("check 2: gdr_copy_to_bar() + read back via cuMemcpy D->H\n");
-        gdr_copy_to_bar(buf_ptr, init_buf, size);
+        printf("check 2: gdr_copy_to_mapping() + read back via cuMemcpy D->H\n");
+        memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
+        gdr_copy_to_mapping(mh, buf_ptr, init_buf, size);
         ASSERTDRV(cuMemcpyDtoH(copy_buf, d_ptr, size));
         //ASSERTDRV(cuCtxSynchronize());
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size), 0);
         memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
-        printf("check 3: gdr_copy_to_bar() + read back via gdr_copy_from_bar()\n");
-        gdr_copy_to_bar(buf_ptr, init_buf, size);
-        gdr_copy_from_bar(copy_buf, buf_ptr, size);
+        printf("check 3: gdr_copy_to_mapping() + read back via gdr_copy_from_mapping()\n");
+        memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
+        gdr_copy_to_mapping(mh, buf_ptr, init_buf, size);
+        gdr_copy_from_mapping(mh, copy_buf, buf_ptr, size);
         //ASSERTDRV(cuCtxSynchronize());
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size), 0);
         memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
         int extra_dwords = 5;
         int extra_off = extra_dwords * sizeof(uint32_t);
-        printf("check 4: gdr_copy_to_bar() + read back via gdr_copy_from_bar() + %d dwords offset\n", extra_dwords);
-        gdr_copy_to_bar(buf_ptr + extra_dwords, init_buf, size - extra_off);
-        gdr_copy_from_bar(copy_buf, buf_ptr + extra_dwords, size - extra_off);
+        printf("check 4: gdr_copy_to_mapping() + read back via gdr_copy_from_mapping() + %d dwords offset\n", extra_dwords);
+        memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
+        gdr_copy_to_mapping(mh, buf_ptr + extra_dwords, init_buf, size - extra_off);
+        gdr_copy_from_mapping(mh, copy_buf, buf_ptr + extra_dwords, size - extra_off);
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size - extra_off), 0);
         memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
         // check for access to misaligned address
         extra_off = 11;
-        printf("check 5: gdr_copy_to_bar() + read back via gdr_copy_from_bar() + %d bytes offset\n", extra_off);
-        gdr_copy_to_bar((char*)buf_ptr + extra_off, init_buf, size - extra_off);
-        gdr_copy_from_bar(copy_buf, (char*)buf_ptr + extra_off, size - extra_off);
+        printf("check 5: gdr_copy_to_mapping() + read back via gdr_copy_from_mapping() + %d bytes offset\n", extra_off);
+        memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
+        gdr_copy_to_mapping(mh, (char*)buf_ptr + extra_off, init_buf, size - extra_off);
+        gdr_copy_from_mapping(mh, copy_buf, (char*)buf_ptr + extra_off, size - extra_off);
         ASSERT_EQ(compare_buf(init_buf, copy_buf, size - extra_off), 0);
 
         printf("unampping\n");


### PR DESCRIPTION
An alternative performance fix for POWER9. 

For example on a 4 GPU server, with this patch copy bandwidth is roughly 37GB/s

```
$ ./copybw.sh 
+ GDRCOPY_ENABLE_LOGGING=1
+ GDRCOPY_LOG_LEVEL=0
+ LD_LIBRARY_PATH=/home/user/drossetti/Coral/gdrcopy:/home/user/drossetti/Coral/gdrcopy:
+ numactl -N 0 -l ./copybw -d 0 -s 262144 -o 0 -c 262144
GPU id:0 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 4 device: 0
GPU id:1 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 5 device: 0
GPU id:2 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 3 device: 0
GPU id:3 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 4 device: 0
selecting device 0
testing size: 262144
rounded size: 262144
device ptr: 7fff79600000
bar_ptr: 0x7fffacd80000
info.va: 7fff79600000
info.mapped_size: 262144
info.page_size: 65536
page offset: 0
user-space pointer:0x7fffacd80000
BAR writing test, size=262144 offset=0 num_iters=10000
DBG:  using plain implementation of gdr_copy_to_bar
BAR1 write BW: 37011.3MB/s
BAR reading test, size=262144 offset=0 num_iters=100
DBG:  using plain implementation of gdr_copy_from_bar
BAR1 read BW: 37041MB/s
unmapping buffer
unpinning buffer
closing gdrdrv

$ ./copybw.sh 
+ GDRCOPY_ENABLE_LOGGING=1
+ GDRCOPY_LOG_LEVEL=0
+ LD_LIBRARY_PATH=/home/user/drossetti/Coral/gdrcopy:/home/user/drossetti/Coral/gdrcopy:
+ numactl -N 0 -l ./copybw -d 0 -s 16777216 -o 0 -c 1048576
GPU id:0 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 4 device: 0
GPU id:1 name:Tesla V100-SXM2-16GB PCI domain: 4 bus: 5 device: 0
GPU id:2 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 3 device: 0
GPU id:3 name:Tesla V100-SXM2-16GB PCI domain: 53 bus: 4 device: 0
selecting device 0
testing size: 16777216
rounded size: 16777216
device ptr: 7fff79600000
bar_ptr: 0x7fff99960000
info.va: 7fff79600000
info.mapped_size: 16777216
info.page_size: 65536
page offset: 0
user-space pointer:0x7fff99960000
BAR writing test, size=1048576 offset=0 num_iters=10000
DBG:  using plain implementation of gdr_copy_to_bar
BAR1 write BW: 38106.5MB/s
BAR reading test, size=1048576 offset=0 num_iters=100
DBG:  using plain implementation of gdr_copy_from_bar
BAR1 read BW: 37759.4MB/s
unmapping buffer
unpinning buffer
closing gdrdrv
```

thi should fix #29 