### PR TITLE
Fixed undefined PVR_POWER9 on linux kernel before 4.12

### DIFF
--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -790,7 +790,7 @@ static int __init gdrdrv_init(void)
     gdr_msg(KERN_INFO, "device registered with major number %d\n", gdrdrv_major);
     gdr_msg(KERN_INFO, "dbg traces %s, info traces %s", dbg_enabled ? "enabled" : "disabled", info_enabled ? "enabled" : "disabled");
 
-#if defined(CONFIG_PPC64)
+#if defined(CONFIG_PPC64) && defined(PVR_POWER9)
     if (pvr_version_is(PVR_POWER9)) {
         // Approximating CPU-GPU coherence with CPU model
         // This might break in the future


### PR DESCRIPTION
PVR_POWER9 is defined from linux kernel 4.12 onward. Hence, the code encounters a compilation error when compiling on linux kernel before 4.12. This change should fix the bug.