### PR TITLE
Create requires filter

### DIFF
--- a/gdrcopy.spec
+++ b/gdrcopy.spec
@@ -19,11 +19,8 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  gcc kernel-headers
 Requires:       %{name}-%{kmod} 
 
-# to get rid of libcuda/libcudart
-AutoReqProv:    no
-# alternatives, not working on RH6 
-#%filter_from_provides /libcuda\\.so.*$/d
-#%global __provides_exclude ^libcuda\\.so.*$
+%filter_from_requires /libcuda.so/d ; /libcudart.so/d ; /libgdrapi.so/d
+%filter_setup
 
 %package devel
 Summary: The development files


### PR DESCRIPTION
This patch creates a filter for the automatic creation of requirements in the RPM package. It eliminates libcuda and libcudart since these are often not installed via RPM. I've also included libgdrapi since it isn't getting detected as something that is provided on RHEL 7.