### PR TITLE
Improve invalidation mechanism and harden security

### DIFF
--- a/gdrapi.c
+++ b/gdrapi.c
@@ -134,7 +134,7 @@ gdr_t gdr_open()
         return NULL;
     }
 
-    int fd = open(gdrinode, O_RDWR);
+    int fd = open(gdrinode, O_RDWR | O_CLOEXEC);
     if (-1 == fd ) {
         int ret = errno;
         gdr_err("error opening driver (errno=%d/%s)\n", ret, strerror(ret));

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -62,10 +62,6 @@ gdr_t gdr_open();
 
 // Destroy library state object, e.g. it closes the connection to kernel-mode
 // driver.
-//
-// Note that altough BAR mappings of GPU memory are destroyed, user-space
-// mappings are not. So therefore user code is responsible of calling
-// gdr_unmap on all mappings before calling gdr_close.
 int gdr_close(gdr_t g);
 
 typedef struct gdr_mh_s {

--- a/gdrapi.h
+++ b/gdrapi.h
@@ -65,7 +65,7 @@ gdr_t gdr_open();
 int gdr_close(gdr_t g);
 
 typedef struct gdr_mh_s {
-  unsigned long h;
+    unsigned long h;
 } gdr_mh_t;
 
 // Map device memory buffer on GPU BAR1, returning an handle.

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -35,7 +35,6 @@
 #include <linux/io.h>
 #include <linux/timex.h>
 #include <linux/timer.h>
-#include <linux/sched/mm.h>
 #include <linux/sched.h>
 
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,32)

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -258,7 +258,7 @@ static int gdrdrv_open(struct inode *inode, struct file *filp)
     int ret = 0;
     gdr_info_t *info = NULL;
 
-    gdr_dbg("minor=%d filep=0x%p\n", minor, filp);
+    gdr_dbg("minor=%d filep=0x%px\n", minor, filp);
     if(minor >= 1) {
         gdr_err("device minor number too big!\n");
         ret = -ENXIO;
@@ -307,7 +307,7 @@ static int gdrdrv_release(struct inode *inode, struct file *filp)
     mutex_lock(&info->lock);
     list_for_each_safe(p, n, &info->mr_list) {
         mr = list_entry(p, gdr_mr_t, node);
-        gdr_info("freeing MR=0x%p\n", mr);
+        gdr_info("freeing MR=0x%px\n", mr);
         if (gdr_mr_is_mapped(mr)) {
             mutex_unlock(&info->lock);
             gdr_mr_destroy_all_mappings(mr);
@@ -405,7 +405,7 @@ static int gdrdrv_pin_buffer(gdr_info_t *info, void __user *_params)
     cycles_t ta, tb;
 
     if (copy_from_user(&params, _params, sizeof(params))) {
-        gdr_err("copy_from_user failed on user pointer %p\n", _params);
+        gdr_err("copy_from_user failed on user pointer 0x%px\n", _params);
         ret = -EFAULT;
         goto out;
     }
@@ -526,7 +526,7 @@ out:
     }
 
     if (!ret && copy_to_user(_params, &params, sizeof(params))) {
-        gdr_err("copy_to_user failed on user pointer %p\n", _params);
+        gdr_err("copy_to_user failed on user pointer 0x%px\n", _params);
         ret = -EFAULT;
     }
 
@@ -542,7 +542,7 @@ static int gdrdrv_unpin_buffer(gdr_info_t *info, void __user *_params)
     gdr_mr_t *mr = NULL;
 
     if (copy_from_user(&params, _params, sizeof(params))) {
-        gdr_err("copy_from_user failed on user pointer %p\n", _params);
+        gdr_err("copy_from_user failed on user pointer 0x%px\n", _params);
         return -EFAULT;
     }
 
@@ -555,7 +555,7 @@ static int gdrdrv_unpin_buffer(gdr_info_t *info, void __user *_params)
         ret = -EINVAL;
     } else {
         if (gdr_mr_is_mapped(mr)) {
-            gdr_err("trying to unpin mapped mr 0x%p\n", mr);
+            gdr_err("trying to unpin mapped mr 0x%px\n", mr);
             ret = -EBUSY;
         } else {
             list_del(&mr->node);
@@ -591,7 +591,7 @@ static int gdrdrv_get_cb_flag(gdr_info_t *info, void __user *_params)
     gdr_mr_t *mr = NULL;
 
     if (copy_from_user(&params, _params, sizeof(params))) {
-        gdr_err("copy_from_user failed on user pointer %p\n", _params);
+        gdr_err("copy_from_user failed on user pointer 0x%px\n", _params);
         return -EFAULT;
     }
     mr = gdr_mr_from_handle(info, params.handle);
@@ -604,7 +604,7 @@ static int gdrdrv_get_cb_flag(gdr_info_t *info, void __user *_params)
     params.flag = !!mr->cb_flag;
 
     if (copy_to_user(_params, &params, sizeof(params))) {
-        gdr_err("copy_to_user failed on user pointer %p\n", _params);
+        gdr_err("copy_to_user failed on user pointer 0x%px\n", _params);
         ret = -EFAULT;
     }
  out:
@@ -620,7 +620,7 @@ static int gdrdrv_get_info(gdr_info_t *info, void __user *_params)
     gdr_mr_t *mr = NULL;
 
     if (copy_from_user(&params, _params, sizeof(params))) {
-        gdr_err("copy_from_user failed on user pointer %p\n", _params);
+        gdr_err("copy_from_user failed on user pointer 0x%px\n", _params);
         ret = -EFAULT;
         goto out;
     }
@@ -640,7 +640,7 @@ static int gdrdrv_get_info(gdr_info_t *info, void __user *_params)
     params.mapped      = gdr_mr_is_mapped(mr);
     params.wc_mapping  = gdr_mr_is_wc_mapping(mr);
     if (copy_to_user(_params, &params, sizeof(params))) {
-        gdr_err("copy_to_user failed on user pointer %p\n", _params);
+        gdr_err("copy_to_user failed on user pointer 0x%px\n", _params);
         ret = -EFAULT;
     }
  out:
@@ -710,7 +710,7 @@ static long gdrdrv_unlocked_ioctl(struct file *filp, unsigned int cmd, unsigned 
 void gdrdrv_vma_close(struct vm_area_struct *vma)
 {
     gdr_mr_t *mr = (gdr_mr_t *)vma->vm_private_data;
-    gdr_dbg("closing vma=0x%p vm_file=0x%p vm_private_data=0x%p mr=0x%p mr->vma=0x%p\n", vma, vma->vm_file, vma->vm_private_data, mr, mr->vma);
+    gdr_dbg("closing vma=0x%px vm_file=0x%px vm_private_data=0x%px mr=0x%px mr->vma=0x%px\n", vma, vma->vm_file, vma->vm_private_data, mr, mr->vma);
     // TODO: handle multiple vma's
     mr->vma = NULL;
     mr->cpu_mapping_type = GDR_MR_NONE;
@@ -793,7 +793,7 @@ static int gdrdrv_mmap(struct file *filp, struct vm_area_struct *vma)
     int p = 0;
     unsigned long vaddr;
 
-    gdr_info("mmap filp=0x%p vma=0x%p vm_file=0x%p start=0x%lx size=%zu off=0x%lx\n", filp, vma, vma->vm_file, vma->vm_start, size, vma->vm_pgoff);
+    gdr_info("mmap filp=0x%px vma=0x%px vm_file=0x%px start=0x%lx size=%zu off=0x%lx\n", filp, vma, vma->vm_file, vma->vm_start, size, vma->vm_pgoff);
 
     if (!info) {
         gdr_err("filp contains no info\n");
@@ -856,7 +856,7 @@ static int gdrdrv_mmap(struct file *filp, struct vm_area_struct *vma)
     // this also works as the mapped flag for this mr
     mr->cpu_mapping_type = GDR_MR_CACHING;
     vma->vm_ops = &gdrdrv_vm_ops;
-    gdr_dbg("overwriting vma->vm_private_data=0x%p with mr=0x%p\n", vma->vm_private_data, mr);
+    gdr_dbg("overwriting vma->vm_private_data=0x%px with mr=0x%px\n", vma->vm_private_data, mr);
     vma->vm_private_data = mr;
     p = 0;
     vaddr = vma->vm_start;
@@ -926,7 +926,7 @@ out:
     } else {
         mr->vma = vma;
         mr->mapping = filp->f_mapping;
-        gdr_dbg("mr vma=0x%p mapping=0x%p\n", mr->vma, mr->mapping);
+        gdr_dbg("mr vma=0x%px mapping=0x%px\n", mr->vma, mr->mapping);
     }
     return ret;
 }

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -580,7 +580,8 @@ static int gdrdrv_pin_buffer(gdr_info_t *info, void __user *_params)
         ret = -ENOMEM;
     }
 
-    list_add(&mr->node, &info->mr_list);
+    if (!ret)
+        list_add(&mr->node, &info->mr_list);
     mutex_unlock(&info->lock);
 
     params.handle = mr->handle;

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -633,11 +633,9 @@ static int gdrdrv_unpin_buffer(gdr_info_t *info, void __user *_params)
         ret = -EINVAL;
     } else {
         if (gdr_mr_is_mapped(mr)) {
-            gdr_err("trying to unpin mapped mr 0x%px\n", mr);
-            ret = -EBUSY;
-        } else {
-            list_del(&mr->node);
+            gdr_mr_destroy_all_mappings(mr);
         }
+        list_del(&mr->node);
     }
     mutex_unlock(&info->lock);
     if (ret)

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -223,7 +223,7 @@ static void gdrdrv_zap_vma(struct address_space *mapping, struct vm_area_struct 
     up_write(&mm->mmap_sem);
 	mmput(mm);
 #else
-    unmap_mapping_range(mapping, vma->vm_start, vma->vm_end - vma->vm_start, 0);
+    unmap_mapping_range(mapping, vma->vm_pgoff << PAGE_SHIFT, vma->vm_end - vma->vm_start, 0);
 #endif
 }
 

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -304,6 +304,16 @@ static int gdrdrv_release(struct inode *inode, struct file *filp)
 
     gdr_dbg("closing\n");
 
+    if (!info) {
+        gdr_err("filp contains no info\n");
+        return -EIO;
+    }
+    // Check that the caller is the same process that did gdrdrv_open
+    if (info->pid != task_pid(current)) {
+        gdr_err("filp is not opened by the current process\n");
+        return -EACCES;
+    }
+
     mutex_lock(&info->lock);
     list_for_each_safe(p, n, &info->mr_list) {
         mr = list_entry(p, gdr_mr_t, node);

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -260,7 +260,7 @@ struct gdr_info {
     // numerical pid here to avoid issues from pid reuse.
     struct pid             *pid;
 
-    // Address space uniqued to this opened file. We need to create a new one
+    // Address space unique to this opened file. We need to create a new one
     // because filp->f_mapping usually points to inode->i_mapping.
     struct address_space    mapping;
 
@@ -828,16 +828,6 @@ static int gdrdrv_remap_gpu_mem(struct vm_area_struct *vma, unsigned long vaddr,
     // Disallow mmapped VMA to propagate to child processes
     vma->vm_flags |= VM_DONTCOPY;
 
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,9)
-    vma->vm_pgoff = pfn;
-    vma->vm_flags |= VM_RESERVED;
-    vma->vm_flags |= VM_IO;
-    if (remap_page_range(vma, vaddr, paddr, size, vma->vm_page_prot)) {
-        gdr_err("error in remap_page_range()\n");
-        ret = -EAGAIN;
-        goto out;
-    }
-#else
     if (is_wcomb) {
         // override prot to create non-coherent WC mappings
         vma->vm_page_prot = pgprot_modify_writecombine(vma->vm_page_prot);
@@ -849,7 +839,6 @@ static int gdrdrv_remap_gpu_mem(struct vm_area_struct *vma, unsigned long vaddr,
         ret = -EAGAIN;
         goto out;
     }
-#endif
 
 out:
     return ret;

--- a/gdrdrv/gdrdrv.c
+++ b/gdrdrv/gdrdrv.c
@@ -986,7 +986,6 @@ out:
             mr->vma = NULL;
             mr->mapping = NULL;
             mr->cpu_mapping_type = GDR_MR_NONE;
-            // TODO: tear down stale partial mappings
         }
     } else {
         mr->vma = vma;

--- a/gdrdrv/gdrdrv.h
+++ b/gdrdrv/gdrdrv.h
@@ -26,7 +26,6 @@
 #define GDRDRV_IOCTL                 0xDA
 
 typedef __u32 gdr_hnd_t;
-#define GDR_HANDLE_MASK ((1UL<<32)-1)
 
 //-----------
 

--- a/gdrdrv/gdrdrv.h
+++ b/gdrdrv/gdrdrv.h
@@ -25,7 +25,7 @@
 
 #define GDRDRV_IOCTL                 0xDA
 
-typedef __u32 gdr_hnd_t;
+typedef __u64 gdr_hnd_t;
 
 //-----------
 


### PR DESCRIPTION
**Problems:**
- Issue #54: GPU buffer invalidation does not tear-down CPU mappings obtained via gdr_map()
- Issue #45: Support for fork
- Issue #62: fd to /dev/gdrdrv should not be sharable with other processes
- Issue #65: gdr_close does not unmap nor clean up internally alloced gdr_memh_t
- gdr_mh_t.h is generated by random number and is used as mmap offset. Sometimes, the mapping range may overlap another already-mapped range -- imagine the first gdr_mh_t.h is 0x0000 and the map size is 0x0100, then the second gdr_mh_t.h is 0x0020. Although it rarely happens, this bug can lead to undesirable and hard-to-detect behaviors.

**This change:**
- fixes the bug that causes unmap_mapping_range to do nothing. We change the address passed to that API to vm_pgoff instead of vm_start.
- prevents copy of vma when fork. Hence, the child processes cannot access the parent's mappings anymore. This behavior aligns with CUDA since CUDA contexts are not transferred to the child processes.
- checks "struct pid *" to ensure that the caller is the same as the process that opens gdrdrv (calls to gdr_open). Hence, the use of opened gdrdrv fd is local to the creator process.
- separates the mapping address space between each process. Two processes map to different GPU memory even with the same mmap offset.
- makes the current gdr_mh_t.h sit next to the previous mapped range. It also guarantees that no two ranges will be overlapped due to the offsets.

**Presubmit testings:**
- gc04:
   - 4.15.0-50-generic #54-Ubuntu SMP Mon May 6 18:46:08 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
   - P100 GPU
   - Intel(R) Xeon(R) CPU E5-2687W v4 @ 3.00GHz
