### PR TITLE
Ignore dependencies in copybw and sanity when building deb package

### DIFF
--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -23,3 +23,5 @@
 override_dh_auto_build:
 	dh_auto_build -- CUDA=$(CUDA)
 
+override_dh_shlibdeps:
+	dh_shlibdeps -Xcopybw -Xsanity


### PR DESCRIPTION
Problem:
- Issue #78.

This change:
- modifies debian/rules to ignore the dependencies in copybw and sanity.