### PR TITLE
Changed "systemctl" to "service" in gdrcopy.spec

### DIFF
--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -76,17 +76,19 @@ fi
 
 /sbin/chkconfig --add gdrcopy
 
-/usr/bin/systemctl start gdrcopy
+service gdrcopy start
 
 %preun %{kmod}
-/usr/bin/systemctl stop gdrcopy
+service gdrcopy stop
 %{MODPROBE} -rq gdrdrv
 if ! ( /sbin/chkconfig --del gdrcopy > /dev/null 2>&1 ); then
    true
 fi              
 
 %postun %{kmod}
-/usr/bin/systemctl daemon-reload
+if [ -e /usr/bin/systemctl ]; then
+    /usr/bin/systemctl daemon-reload
+fi
 
 
 %clean


### PR DESCRIPTION
Problems:
- Issue #80.

This change:
- modifies the pre and post scripts in gdrcopy.spec to use "service" instead of "systemctl".
- checks for the existence of systemctl and does systemctl daemon-reload if found in the post-uninstall script. This step is needed to suppress systemctl error/warning message when changing any services.