### PR TITLE
Ensure aligned allocations in sanity and copybw

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -25,132 +25,141 @@
 #include <map>
 #include <cuda.h>
 
-static std::map<CUdeviceptr, CUdeviceptr> _allocations;
+namespace gdrcopy::test {
+    static std::map<CUdeviceptr, CUdeviceptr> _allocations;
 
-static inline CUresult alignedCUMemAlloc(CUdeviceptr *pptr, size_t psize, bool set_sync_memops)
-{
-    CUresult ret = CUDA_SUCCESS;
-    CUdeviceptr ptr;
-    size_t size = psize + GPU_PAGE_SIZE - 1;
+    static inline CUresult gpuMemAlloc(CUdeviceptr *pptr, size_t psize, bool align_to_gpu_page = true, bool set_sync_memops = true)
+    {
+        CUresult ret = CUDA_SUCCESS;
+        CUdeviceptr ptr;
+        size_t size;
 
-    ret = cuMemAlloc(&ptr, size);
-    if (ret != CUDA_SUCCESS)
-        return ret;
+        if (align_to_gpu_page)
+            size = psize + GPU_PAGE_SIZE - 1;
+        else
+            size = psize;
 
-    if (set_sync_memops) {
-        unsigned int flag = 1;
-        ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
-        if (ret != CUDA_SUCCESS) {
-            cuMemFree(ptr);
+        ret = cuMemAlloc(&ptr, size);
+        if (ret != CUDA_SUCCESS)
+            return ret;
+
+        if (set_sync_memops) {
+            unsigned int flag = 1;
+            ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
+            if (ret != CUDA_SUCCESS) {
+                cuMemFree(ptr);
+                return ret;
+            }
+        }
+
+        if (align_to_gpu_page)
+            *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
+        else
+            *pptr = ptr;
+
+        // Record the actual pointer for doing gpuMemFree later.
+        _allocations[*pptr] = ptr;
+
+        return CUDA_SUCCESS;
+    }
+
+    static inline CUresult gpuMemFree(CUdeviceptr pptr)
+    {
+        CUresult ret = CUDA_SUCCESS;
+        CUdeviceptr ptr;
+
+        if (_allocations.count(pptr) > 0) {
+            ptr = _allocations[pptr];
+            ret = cuMemFree(ptr);
+            if (ret == CUDA_SUCCESS)
+                _allocations.erase(ptr);
             return ret;
         }
+        else
+            return CUDA_ERROR_INVALID_VALUE;
     }
 
-    *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
+    #define ASSERT(x)                                                       \
+        do                                                                  \
+            {                                                               \
+                if (!(x))                                                   \
+                    {                                                       \
+                        fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
+                        exit(EXIT_FAILURE);                                 \
+                    }                                                       \
+            } while (0)
 
-    // Record the actual pointer for doing alignedCUMemFree later.
-    _allocations[*pptr] = ptr;
+    #define ASSERTDRV(stmt)				\
+        do                                          \
+            {                                       \
+                CUresult result = (stmt);           \
+                ASSERT(CUDA_SUCCESS == result);     \
+            } while (0)
 
-    return CUDA_SUCCESS;
-}
+    #define ASSERTRT(stmt)				\
+        do                                          \
+            {                                       \
+                cudaError_t result = (stmt);           \
+                ASSERT(cudaSuccess == result);     \
+            } while (0)
 
-static inline CUresult alignedCUMemFree(CUdeviceptr pptr)
-{
-    CUresult ret = CUDA_SUCCESS;
-    CUdeviceptr ptr;
-
-    if (_allocations.count(pptr) > 0) {
-        ptr = _allocations[pptr];
-        ret = cuMemFree(ptr);
-        if (ret == CUDA_SUCCESS)
-            _allocations.erase(ptr);
-        return ret;
+    static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
+        return a.h == b.h;
     }
-    else
-        return CUDA_ERROR_INVALID_VALUE;
-}
 
-#define ASSERT(x)                                                       \
-    do                                                                  \
-        {                                                               \
-            if (!(x))                                                   \
-                {                                                       \
-                    fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
-                    exit(EXIT_FAILURE);                                 \
-                }                                                       \
-        } while (0)
+    static const gdr_mh_t null_mh = {0};
 
-#define ASSERTDRV(stmt)				\
-    do                                          \
-        {                                       \
-            CUresult result = (stmt);           \
-            ASSERT(CUDA_SUCCESS == result);     \
-        } while (0)
+    #define ASSERT_EQ(P, V) ASSERT((P) == (V))
+    #define CHECK_EQ(P, V) ASSERT((P) == (V))
+    #define ASSERT_NEQ(P, V) ASSERT(!((P) == (V)))
+    #define BREAK_IF_NEQ(P, V) if((P) != (V)) break
+    #define BEGIN_CHECK do
+    #define END_CHECK while(0)
 
-#define ASSERTRT(stmt)				\
-    do                                          \
-        {                                       \
-            cudaError_t result = (stmt);           \
-            ASSERT(cudaSuccess == result);     \
-        } while (0)
-
-static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
-    return a.h == b.h;
-}
-
-static const gdr_mh_t null_mh = {0};
-
-#define ASSERT_EQ(P, V) ASSERT((P) == (V))
-#define CHECK_EQ(P, V) ASSERT((P) == (V))
-#define ASSERT_NEQ(P, V) ASSERT(!((P) == (V)))
-#define BREAK_IF_NEQ(P, V) if((P) != (V)) break
-#define BEGIN_CHECK do
-#define END_CHECK while(0)
-
-static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
-{
-    int diff = 0;
-    if (size % 4 != 0U) {
-        printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
-        size -= (size % 4);
-    }
-    unsigned ndwords = size/sizeof(uint32_t);
-    for(unsigned  w = 0; w < ndwords; ++w) {
-        if (ref_buf[w] != buf[w]) {
-            if (!diff) {
-                printf("%10.10s %8.8s %8.8s\n", "word", "content", "expected");
-            }
-            if (diff < 10) {
-                printf("%10d %08x %08x\n", w, buf[w], ref_buf[w]);
-            }
-            ++diff;
+    static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
+    {
+        int diff = 0;
+        if (size % 4 != 0U) {
+            printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
+            size -= (size % 4);
         }
+        unsigned ndwords = size/sizeof(uint32_t);
+        for(unsigned  w = 0; w < ndwords; ++w) {
+            if (ref_buf[w] != buf[w]) {
+                if (!diff) {
+                    printf("%10.10s %8.8s %8.8s\n", "word", "content", "expected");
+                }
+                if (diff < 10) {
+                    printf("%10d %08x %08x\n", w, buf[w], ref_buf[w]);
+                }
+                ++diff;
+            }
+        }
+        if (diff) {
+            printf("check error: %d different dwords out of %d\n", diff, ndwords);
+        }
+        return diff;
     }
-    if (diff) {
-        printf("check error: %d different dwords out of %d\n", diff, ndwords);
+
+    static void init_hbuf_walking_bit(uint32_t *h_buf, size_t size)
+    {
+        uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
+        unsigned w;
+        ASSERT_NEQ(h_buf, (void*)0);
+        ASSERT_EQ(size % 4, 0U);
+        //OUT << "filling mem with walking bit " << endl;
+        for(w = 0; w<size/sizeof(uint32_t); ++w)
+            h_buf[w] = base_value ^ (1<< (w%32));
     }
-    return diff;
-}
 
-static void init_hbuf_walking_bit(uint32_t *h_buf, size_t size)
-{
-    uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
-    unsigned w;
-    ASSERT_NEQ(h_buf, (void*)0);
-    ASSERT_EQ(size % 4, 0U);
-    //OUT << "filling mem with walking bit " << endl;
-    for(w = 0; w<size/sizeof(uint32_t); ++w)
-        h_buf[w] = base_value ^ (1<< (w%32));
+    static void init_hbuf_linear_ramp(uint32_t *h_buf, size_t size)
+    {
+        uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
+        unsigned w;
+        ASSERT_NEQ(h_buf, (void*)0);
+        ASSERT_EQ(size % 4, 0U);
+        //OUT << "filling mem with walking bit " << endl;
+        for(w = 0; w<size/sizeof(uint32_t); ++w)
+            h_buf[w] = w;
+    }
 }
-
-static void init_hbuf_linear_ramp(uint32_t *h_buf, size_t size)
-{
-    uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
-    unsigned w;
-    ASSERT_NEQ(h_buf, (void*)0);
-    ASSERT_EQ(size % 4, 0U);
-    //OUT << "filling mem with walking bit " << endl;
-    for(w = 0; w<size/sizeof(uint32_t); ++w)
-        h_buf[w] = w;
-}
-

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -31,7 +31,7 @@ static inline CUresult alignedCUMemAlloc(CUdeviceptr *pptr, size_t psize, bool s
 {
     CUresult ret = CUDA_SUCCESS;
     CUdeviceptr ptr;
-    size_t size = psize + GPU_PAGE_SIZE;
+    size_t size = psize + GPU_PAGE_SIZE - 1;
 
     ret = cuMemAlloc(&ptr, size);
     if (ret != CUDA_SUCCESS)

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -46,10 +46,7 @@ static inline CUresult alignedCUMemAlloc(CUdeviceptr *pptr, size_t psize, bool s
         }
     }
 
-    if (ptr & GPU_PAGE_MASK != ptr)
-        *pptr = (ptr + GPU_PAGE_SIZE) & GPU_PAGE_MASK;
-    else
-        *pptr = ptr;
+    *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
 
     // Record the actual pointer for doing alignedCUMemFree later.
     _allocations[*pptr] = ptr;

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -34,6 +34,8 @@ using namespace std;
 #include "gdrapi.h"
 #include "common.hpp"
 
+using namespace gdrcopy::test;
+
 #define OUT cout
 //#define OUT TESTSTACK
 
@@ -123,7 +125,7 @@ main(int argc, char *argv[])
     OUT << "rounded size: " << size << endl;
 
     CUdeviceptr d_A;
-    ASSERTDRV(alignedCUMemAlloc(&d_A, size, true));
+    ASSERTDRV(gpuMemAlloc(&d_A, size));
     OUT << "device ptr: " << hex << d_A << dec << endl;
 
     uint32_t *init_buf = NULL;
@@ -207,7 +209,7 @@ main(int argc, char *argv[])
     OUT << "closing gdrdrv" << endl;
     ASSERT_EQ(gdr_close(g), 0);
 
-    ASSERTDRV(alignedCUMemFree(d_A));
+    ASSERTDRV(gpuMemFree(d_A));
 }
 
 /*

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -123,11 +123,8 @@ main(int argc, char *argv[])
     OUT << "rounded size: " << size << endl;
 
     CUdeviceptr d_A;
-    ASSERTDRV(cuMemAlloc(&d_A, size));
+    ASSERTDRV(alignedCUMemAlloc(&d_A, size, true));
     OUT << "device ptr: " << hex << d_A << dec << endl;
-
-    unsigned int flag = 1;
-    ASSERTDRV(cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, d_A));
 
     uint32_t *init_buf = NULL;
     init_buf = (uint32_t *)malloc(size);
@@ -210,7 +207,7 @@ main(int argc, char *argv[])
     OUT << "closing gdrdrv" << endl;
     ASSERT_EQ(gdr_close(g), 0);
 
-    ASSERTDRV(cuMemFree(d_A));
+    ASSERTDRV(alignedCUMemFree(d_A));
 }
 
 /*

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -230,9 +230,14 @@ START_TEST(basic_unaligned_mapping)
     const size_t A_size = GPU_PAGE_SIZE + sizeof(int);
 
     CUdeviceptr d_A, d_A_boundary;
-    ASSERTDRV(gpuMemAlloc(&d_A, A_size, false, true));
 
-    d_A_boundary = d_A & GPU_PAGE_MASK;
+    // Try until we get an unaligned address. Give up after 100 times.
+    for (int i = 0; i < 100; ++i) {
+        ASSERTDRV(gpuMemAlloc(&d_A, A_size, false, true));
+        d_A_boundary = d_A & GPU_PAGE_MASK;
+        if (d_A != d_A_boundary)
+            break;
+    }
     print_dbg("Second allocation: d_A=0x%llx, size=%zu, GPU-page-boundary 0x%llx\n", d_A, A_size, d_A_boundary);
     if (d_A == d_A_boundary) {
         print_dbg("d_A is aligned. Waiving this test.\n");


### PR DESCRIPTION
Problems:
- Issue #52.
- No unit test for unaligned mapping.
- Allocations in sanity and copybw may be unaligned because cuMemAlloc does not guarantee alignment.

This PR:
- adds a unit test in sanity to test unaligned mapping.
- creates alignedCUMemAlloc and alignedCUMemFree to handle alignment in copybw and sanity.
