### PR TITLE
Fix a bug preventing uninstalling of gdrcopy-kmod.rpm

### DIFF
--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -46,8 +46,6 @@ echo "Building gdrcopy rpm packages version ${VERSION} ..."
 
 echo "Working in $tmpdir ..."
 
-#cp gdrcopy.spec ~/work/mellanox/rpmbuild/SPECS/
-
 ex cd ${TOP_DIR_PATH}
 
 ex mkdir -p $tmpdir/gdrcopy

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -136,3 +136,4 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 - add basic test
 * Thu Sep 15 2016 Davide Rossetti <davide.rossetti@gmail.com> 1.2-1
 - First version of RPM spec
+

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -76,17 +76,19 @@ fi
 
 /sbin/chkconfig --add gdrcopy
 
-/usr/bin/systemctl start gdrcopy
+service gdrcopy start
 
 %preun %{kmod}
-/usr/bin/systemctl stop gdrcopy
+service gdrcopy stop
 %{MODPROBE} -rq gdrdrv
 if ! ( /sbin/chkconfig --del gdrcopy > /dev/null 2>&1 ); then
    true
 fi              
 
 %postun %{kmod}
-/usr/bin/systemctl daemon-reload
+if [ -e /usr/bin/systemctl ]; then
+    /usr/bin/systemctl daemon-reload
+fi
 
 
 %clean

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -79,8 +79,8 @@ fi
 service gdrcopy start
 
 %preun %{kmod}
-service gdrcopy stop
-%{MODPROBE} -rq gdrdrv
+service gdrcopy stop||:
+%{MODPROBE} -rq gdrdrv||:
 if ! ( /sbin/chkconfig --del gdrcopy > /dev/null 2>&1 ); then
    true
 fi              


### PR DESCRIPTION
Problems:
- rpm -e gdrcopy-kmod failed if gdrdrv is not loaded.

This PR:
- fixes that problem, which occurs in %postun %{kmod}.
- removes unused comments.