### PR TITLE
Fix bugs in unit tests

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -25,141 +25,143 @@
 #include <map>
 #include <cuda.h>
 
-namespace gdrcopy::test {
-    static std::map<CUdeviceptr, CUdeviceptr> _allocations;
+namespace gdrcopy {
+    namespace test {
+        static std::map<CUdeviceptr, CUdeviceptr> _allocations;
 
-    static inline CUresult gpuMemAlloc(CUdeviceptr *pptr, size_t psize, bool align_to_gpu_page = true, bool set_sync_memops = true)
-    {
-        CUresult ret = CUDA_SUCCESS;
-        CUdeviceptr ptr;
-        size_t size;
+        static inline CUresult gpuMemAlloc(CUdeviceptr *pptr, size_t psize, bool align_to_gpu_page = true, bool set_sync_memops = true)
+        {
+            CUresult ret = CUDA_SUCCESS;
+            CUdeviceptr ptr;
+            size_t size;
 
-        if (align_to_gpu_page)
-            size = psize + GPU_PAGE_SIZE - 1;
-        else
-            size = psize;
+            if (align_to_gpu_page)
+                size = psize + GPU_PAGE_SIZE - 1;
+            else
+                size = psize;
 
-        ret = cuMemAlloc(&ptr, size);
-        if (ret != CUDA_SUCCESS)
-            return ret;
+            ret = cuMemAlloc(&ptr, size);
+            if (ret != CUDA_SUCCESS)
+                return ret;
 
-        if (set_sync_memops) {
-            unsigned int flag = 1;
-            ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
-            if (ret != CUDA_SUCCESS) {
-                cuMemFree(ptr);
+            if (set_sync_memops) {
+                unsigned int flag = 1;
+                ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
+                if (ret != CUDA_SUCCESS) {
+                    cuMemFree(ptr);
+                    return ret;
+                }
+            }
+
+            if (align_to_gpu_page)
+                *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
+            else
+                *pptr = ptr;
+
+            // Record the actual pointer for doing gpuMemFree later.
+            _allocations[*pptr] = ptr;
+
+            return CUDA_SUCCESS;
+        }
+
+        static inline CUresult gpuMemFree(CUdeviceptr pptr)
+        {
+            CUresult ret = CUDA_SUCCESS;
+            CUdeviceptr ptr;
+
+            if (_allocations.count(pptr) > 0) {
+                ptr = _allocations[pptr];
+                ret = cuMemFree(ptr);
+                if (ret == CUDA_SUCCESS)
+                    _allocations.erase(ptr);
                 return ret;
             }
+            else
+                return CUDA_ERROR_INVALID_VALUE;
         }
 
-        if (align_to_gpu_page)
-            *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
-        else
-            *pptr = ptr;
+        #define ASSERT(x)                                                       \
+            do                                                                  \
+                {                                                               \
+                    if (!(x))                                                   \
+                        {                                                       \
+                            fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
+                            exit(EXIT_FAILURE);                                 \
+                        }                                                       \
+                } while (0)
 
-        // Record the actual pointer for doing gpuMemFree later.
-        _allocations[*pptr] = ptr;
+        #define ASSERTDRV(stmt)				\
+            do                                          \
+                {                                       \
+                    CUresult result = (stmt);           \
+                    ASSERT(CUDA_SUCCESS == result);     \
+                } while (0)
 
-        return CUDA_SUCCESS;
-    }
+        #define ASSERTRT(stmt)				\
+            do                                          \
+                {                                       \
+                    cudaError_t result = (stmt);           \
+                    ASSERT(cudaSuccess == result);     \
+                } while (0)
 
-    static inline CUresult gpuMemFree(CUdeviceptr pptr)
-    {
-        CUresult ret = CUDA_SUCCESS;
-        CUdeviceptr ptr;
-
-        if (_allocations.count(pptr) > 0) {
-            ptr = _allocations[pptr];
-            ret = cuMemFree(ptr);
-            if (ret == CUDA_SUCCESS)
-                _allocations.erase(ptr);
-            return ret;
+        static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
+            return a.h == b.h;
         }
-        else
-            return CUDA_ERROR_INVALID_VALUE;
-    }
 
-    #define ASSERT(x)                                                       \
-        do                                                                  \
-            {                                                               \
-                if (!(x))                                                   \
-                    {                                                       \
-                        fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
-                        exit(EXIT_FAILURE);                                 \
-                    }                                                       \
-            } while (0)
+        static const gdr_mh_t null_mh = {0};
 
-    #define ASSERTDRV(stmt)				\
-        do                                          \
-            {                                       \
-                CUresult result = (stmt);           \
-                ASSERT(CUDA_SUCCESS == result);     \
-            } while (0)
+        #define ASSERT_EQ(P, V) ASSERT((P) == (V))
+        #define CHECK_EQ(P, V) ASSERT((P) == (V))
+        #define ASSERT_NEQ(P, V) ASSERT(!((P) == (V)))
+        #define BREAK_IF_NEQ(P, V) if((P) != (V)) break
+        #define BEGIN_CHECK do
+        #define END_CHECK while(0)
 
-    #define ASSERTRT(stmt)				\
-        do                                          \
-            {                                       \
-                cudaError_t result = (stmt);           \
-                ASSERT(cudaSuccess == result);     \
-            } while (0)
-
-    static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
-        return a.h == b.h;
-    }
-
-    static const gdr_mh_t null_mh = {0};
-
-    #define ASSERT_EQ(P, V) ASSERT((P) == (V))
-    #define CHECK_EQ(P, V) ASSERT((P) == (V))
-    #define ASSERT_NEQ(P, V) ASSERT(!((P) == (V)))
-    #define BREAK_IF_NEQ(P, V) if((P) != (V)) break
-    #define BEGIN_CHECK do
-    #define END_CHECK while(0)
-
-    static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
-    {
-        int diff = 0;
-        if (size % 4 != 0U) {
-            printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
-            size -= (size % 4);
-        }
-        unsigned ndwords = size/sizeof(uint32_t);
-        for(unsigned  w = 0; w < ndwords; ++w) {
-            if (ref_buf[w] != buf[w]) {
-                if (!diff) {
-                    printf("%10.10s %8.8s %8.8s\n", "word", "content", "expected");
-                }
-                if (diff < 10) {
-                    printf("%10d %08x %08x\n", w, buf[w], ref_buf[w]);
-                }
-                ++diff;
+        static int compare_buf(uint32_t *ref_buf, uint32_t *buf, size_t size)
+        {
+            int diff = 0;
+            if (size % 4 != 0U) {
+                printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
+                size -= (size % 4);
             }
+            unsigned ndwords = size/sizeof(uint32_t);
+            for(unsigned  w = 0; w < ndwords; ++w) {
+                if (ref_buf[w] != buf[w]) {
+                    if (!diff) {
+                        printf("%10.10s %8.8s %8.8s\n", "word", "content", "expected");
+                    }
+                    if (diff < 10) {
+                        printf("%10d %08x %08x\n", w, buf[w], ref_buf[w]);
+                    }
+                    ++diff;
+                }
+            }
+            if (diff) {
+                printf("check error: %d different dwords out of %d\n", diff, ndwords);
+            }
+            return diff;
         }
-        if (diff) {
-            printf("check error: %d different dwords out of %d\n", diff, ndwords);
+
+        static void init_hbuf_walking_bit(uint32_t *h_buf, size_t size)
+        {
+            uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
+            unsigned w;
+            ASSERT_NEQ(h_buf, (void*)0);
+            ASSERT_EQ(size % 4, 0U);
+            //OUT << "filling mem with walking bit " << endl;
+            for(w = 0; w<size/sizeof(uint32_t); ++w)
+                h_buf[w] = base_value ^ (1<< (w%32));
         }
-        return diff;
-    }
 
-    static void init_hbuf_walking_bit(uint32_t *h_buf, size_t size)
-    {
-        uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
-        unsigned w;
-        ASSERT_NEQ(h_buf, (void*)0);
-        ASSERT_EQ(size % 4, 0U);
-        //OUT << "filling mem with walking bit " << endl;
-        for(w = 0; w<size/sizeof(uint32_t); ++w)
-            h_buf[w] = base_value ^ (1<< (w%32));
-    }
-
-    static void init_hbuf_linear_ramp(uint32_t *h_buf, size_t size)
-    {
-        uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
-        unsigned w;
-        ASSERT_NEQ(h_buf, (void*)0);
-        ASSERT_EQ(size % 4, 0U);
-        //OUT << "filling mem with walking bit " << endl;
-        for(w = 0; w<size/sizeof(uint32_t); ++w)
-            h_buf[w] = w;
+        static void init_hbuf_linear_ramp(uint32_t *h_buf, size_t size)
+        {
+            uint32_t base_value = 0x3F4C5E6A; // 0xa55ad33d;
+            unsigned w;
+            ASSERT_NEQ(h_buf, (void*)0);
+            ASSERT_EQ(size % 4, 0U);
+            //OUT << "filling mem with walking bit " << endl;
+            for(w = 0; w<size/sizeof(uint32_t); ++w)
+                h_buf[w] = w;
+        }
     }
 }

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -961,7 +961,7 @@ START_TEST(invalidation_fork_after_gdr_map)
         print_dbg("%s: waiting for child to exit\n", myname);
         // Child should exit because of sigbus
         int child_exit_status = -EINVAL;
-        ck_assert_int_eq(wait(&child_exit_status), pid);
+        ck_assert(wait(&child_exit_status) == pid);
         ck_assert_int_eq(child_exit_status, EXIT_SUCCESS);
         print_dbg("%s: trying to read buf_ptr[0] after child exits\n", myname);
         data_from_buf_ptr = buf_ptr[0];
@@ -1038,7 +1038,7 @@ START_TEST(invalidation_fork_child_gdr_map_parent)
     }
     else {
         int child_exit_status = -EINVAL;
-        ck_assert_int_eq(wait(&child_exit_status), pid);
+        ck_assert(wait(&child_exit_status) == pid);
         ck_assert_int_eq(child_exit_status, EXIT_SUCCESS);
 
         ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);
@@ -1261,7 +1261,7 @@ START_TEST(invalidation_unix_sock_shared_fd_gdr_pin_buffer)
 
         print_dbg("%s: Waiting for child to finish\n", myname);
         int child_exit_status = -EINVAL;
-        ck_assert_int_eq(wait(&child_exit_status), pid);
+        ck_assert(wait(&child_exit_status) == pid);
         ck_assert_int_eq(child_exit_status, EXIT_SUCCESS);
     }
 
@@ -1396,7 +1396,7 @@ START_TEST(invalidation_unix_sock_shared_fd_gdr_map)
 
         print_dbg("%s: Waiting for child to finish\n", myname);
         int child_exit_status = -EINVAL;
-        ck_assert_int_eq(wait(&child_exit_status), pid);
+        ck_assert(wait(&child_exit_status) == pid);
         ck_assert_int_eq(child_exit_status, EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
Problems:
- `namespace gdrcopy::test { ... }` syntax is not supported in GCC 4.8.
- ck_assert_int_eq cannot be used with pid_t on libcheck v0.9.8.

This PR:
- changes the namespace definition to `namespace gdrcopy { namespace test { ... } }` for backward compatibility.
- uses ck_assert with pid_t instead.