### PR TITLE
Fix issue 90

### DIFF
--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -37,6 +37,13 @@
 #include <linux/timer.h>
 #include <linux/sched.h>
 
+//-----------------------------------------------------------------------------
+
+static int gdrdrv_major = 0;
+static int gdrdrv_cpu_can_cache_gpu_mappings = 0;
+
+//-----------------------------------------------------------------------------
+
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,32)
 /**
  * This API is available after Linux kernel 2.6.32
@@ -99,7 +106,7 @@ static inline int gdr_pfn_is_ram(unsigned long pfn)
 #else
     unsigned long start = pfn << PAGE_SHIFT;
     unsigned long mask_47bits = (1UL<<47)-1;
-    return 0 == (start & ~mask_47bits);
+    return gdrdrv_cpu_can_cache_gpu_mappings && (0 == (start & ~mask_47bits));
 #endif
 }
 
@@ -272,11 +279,6 @@ struct gdr_info {
     int                     next_handle_overflow;
 };
 typedef struct gdr_info gdr_info_t;
-
-//-----------------------------------------------------------------------------
-
-static int gdrdrv_major = 0;
-static int gdrdrv_cpu_can_cache_gpu_mappings = 0;
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Issue: #90.

This PR:
- modifies gdr_pfn_is_ram for PPC64 to take gdrdrv_cpu_can_cache_gpu_mappings into account.

Presubmit testings:
- On a POWER8 machine with P100 GPU, CUDA10.1, GPU Driver 418.
- On a POWER9 machine with V100 GPU, CUDA10.1, GPU Driver 418, ATS enabled.