### PR TITLE
Remove dependency on libcudart

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ LDFLAGS  := $(CUDA_LIB) -L $(CUDA)/lib64 -L $(GDRAPI_SRC)
 COMMONCFLAGS := -O2
 CFLAGS   += $(COMMONCFLAGS)
 CXXFLAGS += $(COMMONCFLAGS)
-LIBS     := -lcudart -lcuda -lpthread -ldl -lgdrapi
+LIBS     := -lcuda -lpthread -ldl -lgdrapi
 
 SRCS := copybw.cpp sanity.cpp
 EXES := $(SRCS:.cpp=)

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -102,13 +102,6 @@ namespace gdrcopy {
                     ASSERT(CUDA_SUCCESS == result);     \
                 } while (0)
 
-        #define ASSERTRT(stmt)				\
-            do                                          \
-                {                                       \
-                    cudaError_t result = (stmt);           \
-                    ASSERT(cudaSuccess == result);     \
-                } while (0)
-
         static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
             return a.h == b.h;
         }

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -85,7 +85,7 @@ namespace gdrcopy {
                 {                                                               \
                     if (!(x))                                                   \
                         {                                                       \
-                            fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
+                            fprintf(stderr, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__); \
                             exit(EXIT_FAILURE);                                 \
                         }                                                       \
                 } while (0)
@@ -94,6 +94,11 @@ namespace gdrcopy {
             do                                          \
                 {                                       \
                     CUresult result = (stmt);           \
+                    if (result != CUDA_SUCCESS) {       \
+                        const char *_err_name;          \
+                        cuGetErrorName(result, &_err_name); \
+                        fprintf(stderr, "CUDA error: %s\n", _err_name);   \
+                    }                                   \
                     ASSERT(CUDA_SUCCESS == result);     \
                 } while (0)
 


### PR DESCRIPTION
Problems:
- copybw and sanity have dependency on libcudart. However, it is used only for creating cuda context.
- using cudaMalloc(size:=0) for creating cuda context is not supported. Although, it works as intended now, the applications may have undefined behavior in the future.

This PR:
- manually creates the default cuda context using driver APIs.
- removes linking against libcudart. 