### PR TITLE
Extend the test timeout in sanity

### DIFF
--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -1459,6 +1459,10 @@ int main(int argc, char *argv[])
     tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_pin_buffer);
     tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_map);
 
+    tcase_set_timeout(tc_basic, 60);
+    tcase_set_timeout(tc_data_validation, 60);
+    tcase_set_timeout(tc_invalidation, 180);
+
     srunner_run_all(sr, CK_ENV);
     nf = srunner_ntests_failed(sr);
     srunner_free(sr);


### PR DESCRIPTION
Problem:
- Some unit tests in sanity occasionally experience timeout on some systems.
- See nvbug 200559004 for more details.

This PR:
- sets the timeout of basic and data validation test cases to 60 seconds.
- sets the timeout of invalidation test case to 180 seconds.
