### PR TITLE
Fixed compilation bug with libcheck-0.13

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -94,35 +94,35 @@ namespace gdrcopy {
         extern const char *testname;
 
         #define BEGIN_GDRCOPY_TEST(__testname)                                  \
-        START_TEST(__testname)                                                  \
-        testname = #__testname;                                                 \
-        print_dbg("&&&& RUNNING " # __testname "\n");                           \
-        fflush(stdout);                                                         \
-        fflush(stderr);                                                         \
-        pid_t __pid = fork();                                                   \
-        if (__pid < 0) {                                                        \
-            print_dbg("Cannot fork\n");                                         \
-            print_dbg("&&&& FAILED " # __testname "\n");                        \
-            exit(EXIT_FAILURE);                                                 \
-        }                                                                       \
-        if (__pid == 0)
-
-        #define END_GDRCOPY_TEST                                                \
-        if (__pid) {                                                            \
-            int __child_exit_status = -EINVAL;                                  \
-            if (waitpid(__pid, &__child_exit_status, 0) == -1) {                \
-                print_dbg("waitpid returned an error\n");                       \
-                print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);         \
+        START_TEST(__testname) {                                                \
+            testname = #__testname;                                             \
+            print_dbg("&&&& RUNNING " # __testname "\n");                       \
+            fflush(stdout);                                                     \
+            fflush(stderr);                                                     \
+            pid_t __pid = fork();                                               \
+            if (__pid < 0) {                                                    \
+                print_dbg("Cannot fork\n");                                     \
+                print_dbg("&&&& FAILED " # __testname "\n");                    \
                 exit(EXIT_FAILURE);                                             \
             }                                                                   \
-            if (__child_exit_status == EXIT_SUCCESS)                            \
-                print_dbg("&&&& PASSED %s\n", gdrcopy::test::testname);         \
-            else if (__child_exit_status == EXIT_WAIVED)                        \
-                print_dbg("&&&& WAIVED %s\n", gdrcopy::test::testname);         \
-            else                                                                \
-                print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);         \
-        }                                                                       \
-        END_TEST
+            if (__pid == 0) {
+
+        #define END_GDRCOPY_TEST }                                              \
+            if (__pid) {                                                        \
+                int __child_exit_status = -EINVAL;                              \
+                if (waitpid(__pid, &__child_exit_status, 0) == -1) {            \
+                    print_dbg("waitpid returned an error\n");                   \
+                    print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);     \
+                    exit(EXIT_FAILURE);                                         \
+                }                                                               \
+                if (__child_exit_status == EXIT_SUCCESS)                        \
+                    print_dbg("&&&& PASSED %s\n", gdrcopy::test::testname);     \
+                else if (__child_exit_status == EXIT_WAIVED)                    \
+                    print_dbg("&&&& WAIVED %s\n", gdrcopy::test::testname);     \
+                else                                                            \
+                    print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);     \
+            }                                                                   \
+        } END_TEST
 
         #define ASSERT(x)                                                       \
             do                                                                  \


### PR DESCRIPTION
Problem:
- Issue #103.
- libcheck-0.13.0 changes the definition of START_TEST and END_TEST.
- sanity.cpp cannot be compiled because of syntax error due to this change.

This change:
- fixes #103.
- properly adds parentheses to BEGIN_GDRCOPY_TEST and END_GDRCOPY_TEST definitions.
- makes sanity.cpp compatible with libcheck-0.13.0 and prior versions.

Presubmit testings:
- locally on gc11 with libcheck-0.13 and 0.10.