### PR TITLE
introduce CHECK_INC/LIBS in tests/Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ $ make PREFIX=<install-to-this-location> CUDA=<cuda-install-top-dir> all install
 $ sudo ./insmod.sh
 ```
 
+If `libcheck` is installed in a non-standard path and therefore is not
+picked by `pkg-config`, you can set the `PKG_CONFIG_PATH` environment
+variable to the directory which contains the `check.pc` file and pass it
+down to make:
+```shell
+$ PKG_CONFIG_PATH=/check_install_path/lib/pkgconfig/ make <...>
+```
 
 ## Tests
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,8 @@
 DESTBIN ?= 
 CUDA ?= /usr/local/cuda
 
-CHECK_INC  ?= $(shell pkg-config --cflags-only-I check)
-CHECK_LIBS ?= $(shell pkg-config --libs check)
+CHECK_INC  := $(shell pkg-config --cflags-only-I check)
+CHECK_LIBS := $(shell pkg-config --libs check)
 
 GDRAPI_INC := ../include
 GDRAPI_SRC := ../src
@@ -10,7 +10,7 @@ GDRAPI_SRC := ../src
 CUDA_LIB := -L $(CUDA)/lib64 -L $(CUDA)/lib -L /usr/lib64/nvidia -L /usr/lib/nvidia
 CUDA_INC += -I $(CUDA)/include
 
-CPPFLAGS := $(CUDA_INC) -I $(GDRAPI_INC) -I $(GDRAPI_SRC) -I $(CUDA)/include -I $(CHECK_INC)
+CPPFLAGS := $(CUDA_INC) -I $(GDRAPI_INC) -I $(GDRAPI_SRC) -I $(CUDA)/include $(CHECK_INC)
 LDFLAGS  := $(CUDA_LIB) -L $(CUDA)/lib64 -L $(GDRAPI_SRC)
 COMMONCFLAGS := -O2
 CFLAGS   += $(COMMONCFLAGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,13 +1,16 @@
 DESTBIN ?= 
 CUDA ?= /usr/local/cuda
 
+CHECK_INC  ?= $(shell pkg-config --cflags-only-I check)
+CHECK_LIBS ?= $(shell pkg-config --libs check)
+
 GDRAPI_INC := ../include
 GDRAPI_SRC := ../src
 
 CUDA_LIB := -L $(CUDA)/lib64 -L $(CUDA)/lib -L /usr/lib64/nvidia -L /usr/lib/nvidia
 CUDA_INC += -I $(CUDA)/include
 
-CPPFLAGS := $(CUDA_INC) -I $(GDRAPI_INC) -I $(GDRAPI_SRC) -I $(CUDA)/include
+CPPFLAGS := $(CUDA_INC) -I $(GDRAPI_INC) -I $(GDRAPI_SRC) -I $(CUDA)/include -I $(CHECK_INC)
 LDFLAGS  := $(CUDA_LIB) -L $(CUDA)/lib64 -L $(GDRAPI_SRC)
 COMMONCFLAGS := -O2
 CFLAGS   += $(COMMONCFLAGS)
@@ -30,7 +33,7 @@ copybw: copybw.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) -lrt
 
 sanity: sanity.o common.o
-	$(LINK.cc)  -o $@ $^ $(LIBS) `pkg-config --libs check`
+	$(LINK.cc)  -o $@ $^ $(LIBS) $(CHECK_LIBS)
 
 copylat: copylat.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) -lrt

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,8 @@
 DESTBIN ?= 
 CUDA ?= /usr/local/cuda
 
+# note that pkg-config respects PKG_CONFIG_PATH, which can be used
+# to pick libcheck from a user-defined path
 CHECK_INC  := $(shell pkg-config --cflags-only-I check)
 CHECK_LIBS := $(shell pkg-config --libs check)
 


### PR DESCRIPTION
mainly to deal with cases when libbcheck is installed in a non-system dir