### PR TITLE
Added copylat to the rpm and deb packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ sudo rpm -Uvh gdrcopy-devel-<version>.<platform>.rpm
 ### deb package
 
 ```shell
+$ sudo apt install build-essential devscripts debhelper check libsubunit-dev
 $ cd packages
 $ CUDA=<cuda-install-top-dir> ./build-deb-packages.sh
 $ sudo dpkg -i gdrdrv-dkms_<version>_<platform>.deb

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ We provide three ways for building and installing GDRCopy
 ### rpm package
 
 ```shell
+$ sudo yum groupinstall 'Development Tools'
+$ sudo yum install rpm-build make check check-devel subunit subunit-devel
 $ cd packages
 $ CUDA=<cuda-install-top-dir> ./build-rpm-packages.sh
 $ sudo rpm -Uvh gdrcopy-kmod-<version>.<platform>.rpm

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -63,7 +63,7 @@ ex mv gdrcopy gdrcopy-${VERSION}
 ex tar czvf gdrcopy_${VERSION}.orig.tar.gz gdrcopy-${VERSION}
 
 ex cd $tmpdir/gdrcopy-${VERSION}
-ex debuild --set-envvar=CUDA=$CUDA -us -uc
+ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} -us -uc
 
 echo
 echo "Building dkms module ..."

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
+# See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+DEBIAN_VERSION=2
+
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."
 
@@ -35,6 +39,7 @@ if [ "X$VERSION" == "X" ]; then
     echo "Failed to get version numbers!" >&2
     exit 1
 fi
+FULL_VERSION="${VERSION}-${DEBIAN_VERSION}"
 
 tmpdir=`mktemp -d /tmp/gdr.XXXXXX`
 if [ ! -d "$tmpdir" ]; then
@@ -42,7 +47,7 @@ if [ ! -d "$tmpdir" ]; then
     exit 1
 fi
 
-echo "Building gdrcopy debian packages version ${VERSION} ..."
+echo "Building gdrcopy debian packages version ${FULL_VERSION} ..."
 
 echo "Working in $tmpdir ..."
 
@@ -56,7 +61,7 @@ ex cp README.md $tmpdir/gdrcopy/debian/README.source
 ex rm -f $tmpdir/gdrcopy_${VERSION}.orig.tar.gz
 
 ex cd $tmpdir/gdrcopy
-ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
+ex find . -type f -exec sed -i "s/@VERSION@/${FULL_VERSION}/g" {} +
 
 ex cd $tmpdir
 ex mv gdrcopy gdrcopy-${VERSION}
@@ -67,15 +72,15 @@ ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_P
 
 echo
 echo "Building dkms module ..."
-ex cd $tmpdir/gdrcopy-$VERSION/src/gdrdrv
+ex cd $tmpdir/gdrcopy-${VERSION}/src/gdrdrv
 ex make clean
 
-ex mkdir -p $tmpdir/gdrdrv-dkms-$VERSION/
-ex cp -r $tmpdir/gdrcopy-$VERSION/src/gdrdrv $tmpdir/gdrdrv-dkms-$VERSION/gdrdrv-$VERSION
-ex cp ${SCRIPT_DIR_PATH}/dkms.conf $tmpdir/gdrdrv-dkms-$VERSION/gdrdrv-$VERSION/
-ex cd $tmpdir/gdrdrv-dkms-$VERSION/
+ex mkdir -p $tmpdir/gdrdrv-dkms-${VERSION}/
+ex cp -r $tmpdir/gdrcopy-${VERSION}/src/gdrdrv $tmpdir/gdrdrv-dkms-${VERSION}/gdrdrv-${VERSION}
+ex cp ${SCRIPT_DIR_PATH}/dkms.conf $tmpdir/gdrdrv-dkms-${VERSION}/gdrdrv-${VERSION}/
+ex cd $tmpdir/gdrdrv-dkms-${VERSION}/
 ex cp -r ${SCRIPT_DIR_PATH}/dkms/* .
-ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
+ex find . -type f -exec sed -i "s/@VERSION@/${FULL_VERSION}/g" {} +
 ex find . -type f -exec sed -i "s/@MODULE_LOCATION@/${MODULE_SUBDIR//\//\\/}/g" {} +
 
 ex dpkg-buildpackage -S -us -uc

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
+# See https://rpm-packaging-guide.github.io/#preamble-items
+RPM_VERSION=4
+
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."
 
@@ -64,7 +68,7 @@ ex mkdir -p $tmpdir/topdir/{SRPMS,RPMS,SPECS,BUILD,SOURCES}
 ex cp gdrcopy-$VERSION/gdrcopy.spec $tmpdir/topdir/SPECS/
 ex cp gdrcopy-$VERSION.tar.gz $tmpdir/topdir/SOURCES/
 
-rpmbuild -ba --nodeps --define "_topdir $tmpdir/topdir" --define 'dist %{nil}' --define "CUDA $CUDA" --define "GDR_VERSION ${VERSION}" --define "KVERSION $(uname -r)" --define "MODULE_LOCATION ${MODULE_SUBDIR}" $tmpdir/topdir/SPECS/gdrcopy.spec
+rpmbuild -ba --nodeps --define "_topdir $tmpdir/topdir" --define "_release ${RPM_VERSION}" --define 'dist %{nil}' --define "CUDA $CUDA" --define "GDR_VERSION ${VERSION}" --define "KVERSION $(uname -r)" --define "MODULE_LOCATION ${MODULE_SUBDIR}" $tmpdir/topdir/SPECS/gdrcopy.spec
 rpms=`ls -1 $tmpdir/topdir/RPMS/*/*.rpm`
 srpm=`ls -1 $tmpdir/topdir/SRPMS/`
 echo $srpm $rpms

--- a/packages/debian/changelog
+++ b/packages/debian/changelog
@@ -1,7 +1,17 @@
-gdrcopy (@VERSION@) stable; urgency=low
+gdrcopy (@VERSION@) unstable; urgency=low
+
+  * Introduce copylat test application.
+  * Introduce basic_with_tokens and invalidation_fork_child_gdr_pin_parent_with_tokens sub-tests in sanity.
+  * Remove the dependency with libcudart.so.
+  * Clean up the code in the tests folder.
+  * Change the package maintainer to Davide Rossetti.
+
+ -- Davide Rossetti <drossetti@nvidia.com>  Mon, 02 Mar 2020 11:59:59 -0700
+
+gdrcopy (2.0) stable; urgency=low
 
   * Improve copy performance with unrolling in POWERPC.
-  * Creates sanity unit test for testing the functionality and security.
+  * Create sanity unit test for testing the functionality and security.
   * Consolidate basic and validate into sanity unit test.
   * Introduce compile time and runtime version checking in libgdrapi.
   * Improve rpm packaging.

--- a/packages/debian/control
+++ b/packages/debian/control
@@ -1,6 +1,6 @@
 Source: gdrcopy
 Priority: optional
-Maintainer: Pak Markthub <pmarkthub@nvidia.com>
+Maintainer: Davide Rossetti <drossetti@nvidia.com>
 Build-Depends: debhelper (>= 10), check, libsubunit-dev
 Standards-Version: @VERSION@
 Section: libs

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -24,4 +24,4 @@ override_dh_auto_build:
 	dh_auto_build -- CUDA=$(CUDA)
 
 override_dh_shlibdeps:
-	dh_shlibdeps -Xcopybw -Xsanity
+	dh_shlibdeps -Xcopybw -Xcopylat -Xsanity 

--- a/packages/dkms/debian/changelog
+++ b/packages/dkms/debian/changelog
@@ -1,4 +1,10 @@
-gdrdrv-dkms (@VERSION@) stable; urgency=low
+gdrdrv-dkms (@VERSION@) unstable; urgency=low
+
+  * Change the package maintainer to Davide Rossetti.
+
+ -- Davide Rossetti <drossetti@nvidia.com>  Mon, 02 Mar 2020 11:59:59 -0700
+
+gdrdrv-dkms (2.0) stable; urgency=low
 
   * Harden security in gdrdrv.
   * Enable cached mappings in POWER9.

--- a/packages/dkms/debian/control
+++ b/packages/dkms/debian/control
@@ -1,7 +1,7 @@
 Source: gdrdrv-dkms
 Section: misc
 Priority: optional
-Maintainer: Pak Markthub <pmarkthub@nvidia.com>
+Maintainer: Davide Rossetti <drossetti@nvidia.com>
 Build-Depends: debhelper (>= 10), dkms
 Standards-Version: @VERSION@
 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -1,4 +1,4 @@
-%{!?_release: %define _release 3}
+%{!?_release: %define _release 4}
 %{!?CUDA: %define CUDA /usr/local/cuda}
 %{!?GDR_VERSION: %define GDR_VERSION 2.0}
 %{!?KVERSION: %define KVERSION %(uname -r)}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -1,4 +1,4 @@
-%{!?_release: %define _release 4}
+%{!?_release: %define _release 1}
 %{!?CUDA: %define CUDA /usr/local/cuda}
 %{!?GDR_VERSION: %define GDR_VERSION 2.0}
 %{!?KVERSION: %define KVERSION %(uname -r)}
@@ -117,6 +117,12 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
+* Mon Mar 02 2020 Davide Rossetti <drossetti@nvidia.com> 2.0-4
+- Introduce copylat test application.
+- Introduce basic_with_tokens and invalidation_fork_child_gdr_pin_parent_with_tokens sub-tests in sanity.
+- Remove the dependency with libcudart.so.
+- Clean up the code in the tests folder.
+- Change the package maintainer to Davide Rossetti.
 * Mon Sep 16 2019 Pak Markthub <pmarkthub@nvidia.com> 2.0-3
 - Harden security in gdrdrv.
 - Enable cached mappings in POWER9.

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -98,6 +98,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 %files
 %{_prefix}/bin/copybw
+%{_prefix}/bin/copylat
 %{_prefix}/bin/sanity
 %{_libdir}/libgdrapi.so.?.?
 %{_libdir}/libgdrapi.so.?

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,6 +42,7 @@ install: exes
 	@ echo "installing exes in $(DESTBIN)..." && \
 	mkdir -p $(DESTBIN) && \
 	install -D -v -m u=rwx,g=rx,o=rx copybw -t $(DESTBIN) && \
+	install -D -v -m u=rwx,g=rx,o=rx copylat -t $(DESTBIN) && \
 	install -D -v -m u=rwx,g=rx,o=rx sanity -t $(DESTBIN)
 
 .PHONY: clean all exes install


### PR DESCRIPTION
Problems:
- copylat is neither installed nor included in the deb / rpm packages.
- document dependencies for package building 

This PR:
- fixes issue #108.
- includes copylat in the deb package.
- modifies the _install_ command in tests/Makefile to also install copylat.
- modifies packages/build-deb-package.sh to respect user-defined PKG_CONFIG_PATH.
- introduces debian version in the deb packages.
- fixes issue #100.