### PR TITLE
unblock multi-threaded use cases

### DIFF
--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -266,7 +266,7 @@ struct gdr_info {
     // Pointer to the pid struct of the creator process. We do not use
     // numerical pid here to avoid issues from pid reuse.
     struct pid             *pid;
-    pid_t                   tgid;
+    struct pid             *tgid;
 
     // Address space unique to this opened file. We need to create a new one
     // because filp->f_mapping usually points to inode->i_mapping.
@@ -287,10 +287,10 @@ static int gdrdrv_check_same_process(gdr_info_t *info, struct task_struct *tsk)
     BUG_ON(0 == info);
     BUG_ON(0 == tsk);
     same_proc = (info->pid == task_pid(tsk))        // either exactly the same task
-        || (info->tgid == task_tgid_nr(tsk)) ; // or tasks belonging to the task group
+        || (info->tgid == task_tgid(tsk)) ; // or tasks belonging to the task group
     if (!same_proc) {
-        gdr_dbg("check failed, info:{pid=%p tgid=0x%x} this tsk={pid=%p tgid=0x%x}\n",
-                info->pid, info->tgid, task_pid(tsk), task_tgid_nr(tsk));
+        gdr_dbg("check failed, info:{pid=%p tgid=%p} this tsk={pid=%p tgid=%p}\n",
+                info->pid, info->tgid, task_pid(tsk), task_tgid(tsk));
     }
     return same_proc;
 }
@@ -324,7 +324,7 @@ static int gdrdrv_open(struct inode *inode, struct file *filp)
     // here we track the process owning the driver fd and prevent other process
     // to use it.
     info->pid = task_pid(current);
-    info->tgid = task_tgid_nr(current);
+    info->tgid = task_tgid(current);
 
     address_space_init_once(&info->mapping);
     info->mapping.host = inode;

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -36,6 +36,9 @@
 #include <linux/timex.h>
 #include <linux/timer.h>
 #include <linux/sched.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
+#include <linux/sched/signal.h>
+#endif
 
 //-----------------------------------------------------------------------------
 

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -283,10 +283,16 @@ typedef struct gdr_info gdr_info_t;
 
 static int gdrdrv_check_same_process(gdr_info_t *info, struct task_struct *tsk)
 {
+    int same_proc;
     BUG_ON(0 == info);
     BUG_ON(0 == tsk);
-    return (info->pid == task_pid(tsk))        // either exactly the same task
+    same_proc = (info->pid == task_pid(tsk))        // either exactly the same task
         || (info->tgid == task_tgid_nr(tsk)) ; // or tasks belonging to the task group
+    if (!same_proc) {
+        gdr_dbg("check failed, info:{pid=%p tgid=0x%x} this tsk={pid=%p tgid=0x%x}\n",
+                info->pid, info->tgid, task_pid(tsk), task_tgid_nr(tsk));
+    }
+    return same_proc;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -965,7 +965,7 @@ static int gdrdrv_mmap(struct file *filp, struct vm_area_struct *vma)
     // this also works as the mapped flag for this mr
     mr->cpu_mapping_type = GDR_MR_CACHING;
     vma->vm_ops = &gdrdrv_vm_ops;
-    gdr_dbg("overwriting vma->vm_private_data=0x%px with mr=0x%px\n", vma->vm_private_data, mr);
+    gdr_dbg("overwriting vma->vm_private_data=%px with mr=%px\n", vma->vm_private_data, mr);
     vma->vm_private_data = mr;
 
     // check for physically contiguous IO ranges

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -156,7 +156,7 @@ static inline int gdr_pfn_is_ram(unsigned long pfn)
 
 #define DEVNAME "gdrdrv"
 
-#define gdr_msg(KRNLVL, FMT, ARGS...) printk(KRNLVL DEVNAME ":" FMT, ## ARGS)
+#define gdr_msg(KRNLVL, FMT, ARGS...) printk(KRNLVL DEVNAME ":%s:" FMT, __func__, ## ARGS)
 //#define gdr_msg(KRNLVL, FMT, ARGS...) printk_ratelimited(KRNLVL DEVNAME ":" FMT, ## ARGS)
 
 static int dbg_enabled = 0;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -1568,7 +1568,7 @@ void *thr_fun_cleanup(void *data)
     return NULL;
 }
 
-BEGIN_GDRCOPY_TEST(child_thread_pins_buffer)
+BEGIN_GDRCOPY_TEST(basic_child_thread_pins_buffer)
 {
     const size_t _size = GPU_PAGE_SIZE * 16;
     mt_test_info t = { 0, 0, 0, 0, null_mh, false };
@@ -1657,7 +1657,7 @@ int main(int argc, char *argv[])
     tcase_add_test(tc_basic, basic);
     tcase_add_test(tc_basic, basic_with_tokens);
     tcase_add_test(tc_basic, basic_unaligned_mapping);
-    tcase_add_test(tc_basic, child_thread_pins_buffer);
+    tcase_add_test(tc_basic, basic_child_thread_pins_buffer);
 
     suite_add_tcase(s, tc_data_validation);
     tcase_add_test(tc_data_validation, data_validation);


### PR DESCRIPTION
why: in gdrdrv, the current check for "same process" is too strong, and excludes tasks in same tgid.
how: relax the check on tsks

fixes #120 