### PR TITLE
Add multiarch support for deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-DESTDIR ?= 
-PREFIX ?= /usr
-DESTLIB ?= $(DESTDIR)/$(PREFIX)/lib64
-DESTBIN ?= $(DESTDIR)/$(PREFIX)/bin
+prefix      ?= /usr/local
+exec_prefix ?= $(prefix)
+libdir      ?= $(exec_prefix)/lib
+bindir      ?= $(exec_prefix)/bin
+includedir  ?= $(prefix)/include
+
+DESTDIR := $(abspath $(DESTDIR))
+DESTLIB = $(DESTDIR)$(libdir)
+DESTBIN = $(DESTDIR)$(bindir)
+DESTINC = $(DESTDIR)$(includedir)
+
 CUDA ?= /usr/local/cuda
 
 LIB_MAJOR_VER ?= $(shell awk '/\#define GDR_API_MAJOR_VERSION/ { print $$3 }' include/gdrapi.h | tr -d '\n')
@@ -38,11 +45,11 @@ exes: lib
 install: lib_install exes_install
 
 lib_install: lib
-	@ echo "installing in $(DESTDIR)/$(PREFIX)..." && \
+	@ echo "installing in $(DESTLIB) $(DESTINC)..." && \
 	mkdir -p $(DESTLIB) && \
 	install -D -v -m u=rw,g=rw,o=r src/$(LIB_DYNAMIC) -t $(DESTLIB) && \
-	mkdir -p $(DESTDIR)/$(PREFIX)/include/ && \
-	install -D -v -m u=rw,g=rw,o=r include/* -t $(DESTDIR)/$(PREFIX)/include/; \
+	mkdir -p $(DESTINC) && \
+	install -D -v -m u=rw,g=rw,o=r include/* -t $(DESTINC); \
 	cd $(DESTLIB); \
 	ln -sf $(LIB_DYNAMIC) $(LIB_SONAME); \
 	ln -sf $(LIB_SONAME) $(LIB_BASENAME);

--- a/packages/debian/gdrcopy.dirs
+++ b/packages/debian/gdrcopy.dirs
@@ -1,3 +1,0 @@
-usr/lib64
-usr/bin
-usr/include

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -24,4 +24,7 @@ override_dh_auto_build:
 	dh_auto_build -- CUDA=$(CUDA)
 
 override_dh_shlibdeps:
-	dh_shlibdeps -Xcopybw -Xcopylat -Xsanity 
+	dh_shlibdeps -Xcopybw -Xcopylat -Xsanity
+
+override_dh_auto_install:
+	dh_auto_install -- prefix=/usr libdir=/usr/lib/$(DEB_HOST_MULTIARCH)

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -58,7 +58,7 @@ echo "building"
 make -j CUDA=${CUDA}
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_prefix}
+make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} libdir=%{_libdir}
 make drv_install DESTDIR=$RPM_BUILD_ROOT 
 
 # Install gdrdrv service script


### PR DESCRIPTION
The previous Makefile was not following the GNU conventions:
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

As a result, it was not possibly to properly override the library install in
the debian package script.

The deb package now correctly installs the library in the multiarch directory.
See https://wiki.debian.org/Multiarch/Implementation

Fix #142

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>