### PR TITLE
Small fixes to RPM spec file

### DIFF
--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -66,7 +66,7 @@ install -d $RPM_BUILD_ROOT/etc/init.d
 install -m 0755 $RPM_BUILD_DIR/%{name}-%{version}/init.d/gdrcopy $RPM_BUILD_ROOT/etc/init.d
 
 %post %{kmod}
-/sbin/depmod -a
+/sbin/depmod -a %{KVERSION}
 %{MODPROBE} -rq gdrdrv||:
 %{MODPROBE} gdrdrv||:
 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -55,7 +55,7 @@ Kernel-mode driver for GDRCopy.
 
 %build
 echo "building"
-make -j CUDA=${CUDA}
+make -j CUDA=%{CUDA}
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} libdir=%{_libdir}


### PR DESCRIPTION
- Use `%{CUDA}` instead of `${CUDA}`.
- Run depmod specifically for the kernel that the module was build for instead of the running kernel