### PR TITLE
Make build-deb-packages.sh runnable on docker containers without mounting /usr/src and /lib/modules

### DIFF
--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -21,7 +21,7 @@
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_build:
-	dh_auto_build -- CUDA=$(CUDA)
+	dh_auto_build -- CUDA=$(CUDA) lib exes
 
 override_dh_shlibdeps:
 	dh_shlibdeps -Xcopybw -Xcopylat -Xsanity


### PR DESCRIPTION
Problem:
- Issue #148.
- When creating gdrcopy_*.deb, dh_auto_build also does make gdrdrv. In many docker images, an error occurs because of the lack of linux kernel source.

This PR:
- fixes the above problem.

Presubmit testing:
- Successfully run `build-deb-packages.sh` on docker image nvidia/cuda:11.0-devel.
- The built gdrdrv-dkms.deb is also successfully installed on the host machine (Ubuntu 18.04).