### PR TITLE
Improve gdr_open error message in tests

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -111,6 +111,15 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
+#define GDR_OPEN_SAFE() ({                                                          \
+        gdr_t _g = gdr_open();                                                      \
+        if (!_g) {                                                                  \
+            fprintf(stderr, "gdr_open error: Is gdrdrv installed and loaded?\n");   \
+            exit(EXIT_FAILURE);                                                     \
+        }                                                                           \
+        _g;                                                                         \
+    })
+
 
 namespace gdrcopy {
     namespace test {

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -111,19 +111,21 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
-#define GDR_OPEN_SAFE() ({                                                              \
-        gdr_t _g = gdr_open();                                                          \
-        if (!_g) {                                                                      \
-            fprintf(stderr, "gdr_open error: Is gdrdrv driver installed and loaded?\n");\
-            exit(EXIT_FAILURE);                                                         \
-        }                                                                               \
-        _g;                                                                             \
-    })
 
 
 namespace gdrcopy {
     namespace test {
         extern std::map<CUdeviceptr, CUdeviceptr> _allocations;
+
+        static inline gdr_t gdr_open_safe()
+        {
+            gdr_t g = gdr_open();
+            if (!g) {
+                fprintf(stderr, "gdr_open error: Is gdrdrv driver installed and loaded?\n");
+                exit(EXIT_FAILURE);
+            }
+            return g;
+        }
 
         static inline CUresult gpuMemAlloc(CUdeviceptr *pptr, size_t psize, bool align_to_gpu_page = true, bool set_sync_memops = true)
         {

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -111,13 +111,13 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
-#define GDR_OPEN_SAFE() ({                                                          \
-        gdr_t _g = gdr_open();                                                      \
-        if (!_g) {                                                                  \
-            fprintf(stderr, "gdr_open error: Is gdrdrv installed and loaded?\n");   \
-            exit(EXIT_FAILURE);                                                     \
-        }                                                                           \
-        _g;                                                                         \
+#define GDR_OPEN_SAFE() ({                                                              \
+        gdr_t _g = gdr_open();                                                          \
+        if (!_g) {                                                                      \
+            fprintf(stderr, "gdr_open error: Is gdrdrv driver installed and loaded?\n");\
+            exit(EXIT_FAILURE);                                                         \
+        }                                                                               \
+        _g;                                                                             \
     })
 
 

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -144,8 +144,7 @@ int main(int argc, char *argv[])
     ASSERT_NEQ(init_buf, (void*)0);
     init_hbuf_walking_bit(init_buf, size);
 
-    gdr_t g = gdr_open();
-    ASSERT_NEQ(g, (void*)0);
+    gdr_t g = GDR_OPEN_SAFE();
 
     gdr_mh_t mh;
     BEGIN_CHECK {

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     ASSERT_NEQ(init_buf, (void*)0);
     init_hbuf_walking_bit(init_buf, size);
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
 
     gdr_mh_t mh;
     BEGIN_CHECK {

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
 
     cout << endl;
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
 
     cout << endl;
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -180,7 +180,6 @@ int main(int argc, char *argv[])
     cout << endl;
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
     BEGIN_CHECK {

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -178,7 +178,6 @@ BEGIN_GDRCOPY_TEST(basic)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
     CUdeviceptr d_ptr = d_A;
@@ -215,7 +214,6 @@ BEGIN_GDRCOPY_TEST(basic_with_tokens)
     ASSERTDRV(cuPointerGetAttribute(&tokens, CU_POINTER_ATTRIBUTE_P2P_TOKENS, d_A));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
     CUdeviceptr d_ptr = d_A;
@@ -273,7 +271,6 @@ BEGIN_GDRCOPY_TEST(basic_unaligned_mapping)
     print_dbg("d_A is unaligned\n");
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     // Try mapping with unaligned address. This should fail.
     print_dbg("Try mapping d_A as is.\n");
@@ -355,7 +352,6 @@ BEGIN_GDRCOPY_TEST(data_validation)
     memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
 
@@ -468,7 +464,6 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_gdr_close)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
     CUdeviceptr d_ptr = d_A;
@@ -544,7 +539,6 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_cumemfree)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
     CUdeviceptr d_ptr = d_A;
@@ -623,7 +617,6 @@ BEGIN_GDRCOPY_TEST(invalidation_two_mappings)
     }
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh[2];
 
@@ -769,7 +762,6 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_access_after_cumemfree)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
 
@@ -878,7 +870,6 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_after_gdr_map)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
 
@@ -1018,7 +1009,6 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_map_parent)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
 
@@ -1131,7 +1121,6 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_map_and_free)
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
     gdr_t g = gdr_open_safe();
-    ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
 
@@ -1261,7 +1250,6 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_pin_buffer)
 
         print_dbg("%s: Calling gdr_open\n", myname);
         gdr_t g = gdr_open_safe();
-        ASSERT_NEQ(g, (void*)0);
 
         fd = g->fd;
         print_dbg("%s: Extracted fd from gdr_t got fd %d\n", myname, fd);
@@ -1385,7 +1373,6 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_map)
 
         print_dbg("%s: Calling gdr_open\n", myname);
         gdr_t g = gdr_open_safe();
-        ASSERT_NEQ(g, (void*)0);
 
         print_dbg("%s: Calling gdr_pin_buffer\n", myname);
         gdr_mh_t mh;
@@ -1467,7 +1454,6 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_pin_parent_with_tokens)
         write_fd = filedes_0[1];
 
         gdr_t g = gdr_open_safe();
-        ASSERT_NEQ(g, (void*)0);
 
         ASSERT_EQ(read(read_fd, &d_A, sizeof(CUdeviceptr)), sizeof(CUdeviceptr));
         ASSERT_EQ(read(read_fd, &tokens, sizeof(CUDA_POINTER_ATTRIBUTE_P2P_TOKENS)), sizeof(CUDA_POINTER_ATTRIBUTE_P2P_TOKENS));
@@ -1580,7 +1566,6 @@ BEGIN_GDRCOPY_TEST(basic_child_thread_pins_buffer)
     ASSERTDRV(cuMemsetD8(t.d_buf, 0xA5, t.size));
 
     t.g = gdr_open_safe();
-    ASSERT_NEQ(t.g, (void*)0);
     {
         pthread_t tid;
         t.use_barrier = false;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -177,7 +177,7 @@ BEGIN_GDRCOPY_TEST(basic)
     CUdeviceptr d_A;
     ASSERTDRV(gpuMemAlloc(&d_A, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -214,7 +214,7 @@ BEGIN_GDRCOPY_TEST(basic_with_tokens)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuPointerGetAttribute(&tokens, CU_POINTER_ATTRIBUTE_P2P_TOKENS, d_A));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -272,7 +272,7 @@ BEGIN_GDRCOPY_TEST(basic_unaligned_mapping)
     }
     print_dbg("d_A is unaligned\n");
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     // Try mapping with unaligned address. This should fail.
@@ -354,7 +354,7 @@ BEGIN_GDRCOPY_TEST(data_validation)
     init_hbuf_walking_bit(init_buf, size);
     memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -467,7 +467,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_gdr_close)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -543,7 +543,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -622,7 +622,7 @@ BEGIN_GDRCOPY_TEST(invalidation_two_mappings)
         ASSERTDRV(cuMemsetD8(d_A[i], 0x95, size));
     }
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh[2];
@@ -768,7 +768,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -877,7 +877,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_after_gdr_map)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1017,7 +1017,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_map_parent)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1130,7 +1130,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_map_and_free)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = GDR_OPEN_SAFE();
+    gdr_t g = gdr_open_safe();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1260,7 +1260,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_pin_buffer)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = GDR_OPEN_SAFE();
+        gdr_t g = gdr_open_safe();
         ASSERT_NEQ(g, (void*)0);
 
         fd = g->fd;
@@ -1384,7 +1384,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_map)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = GDR_OPEN_SAFE();
+        gdr_t g = gdr_open_safe();
         ASSERT_NEQ(g, (void*)0);
 
         print_dbg("%s: Calling gdr_pin_buffer\n", myname);
@@ -1466,7 +1466,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_pin_parent_with_tokens)
         read_fd = filedes_1[0];
         write_fd = filedes_0[1];
 
-        gdr_t g = GDR_OPEN_SAFE();
+        gdr_t g = gdr_open_safe();
         ASSERT_NEQ(g, (void*)0);
 
         ASSERT_EQ(read(read_fd, &d_A, sizeof(CUdeviceptr)), sizeof(CUdeviceptr));
@@ -1579,7 +1579,7 @@ BEGIN_GDRCOPY_TEST(basic_child_thread_pins_buffer)
     ASSERTDRV(gpuMemAlloc(&t.d_buf, t.size));
     ASSERTDRV(cuMemsetD8(t.d_buf, 0xA5, t.size));
 
-    t.g = GDR_OPEN_SAFE();
+    t.g = gdr_open_safe();
     ASSERT_NEQ(t.g, (void*)0);
     {
         pthread_t tid;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -177,7 +177,7 @@ BEGIN_GDRCOPY_TEST(basic)
     CUdeviceptr d_A;
     ASSERTDRV(gpuMemAlloc(&d_A, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -214,7 +214,7 @@ BEGIN_GDRCOPY_TEST(basic_with_tokens)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuPointerGetAttribute(&tokens, CU_POINTER_ATTRIBUTE_P2P_TOKENS, d_A));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -272,7 +272,7 @@ BEGIN_GDRCOPY_TEST(basic_unaligned_mapping)
     }
     print_dbg("d_A is unaligned\n");
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     // Try mapping with unaligned address. This should fail.
@@ -354,7 +354,7 @@ BEGIN_GDRCOPY_TEST(data_validation)
     init_hbuf_walking_bit(init_buf, size);
     memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -467,7 +467,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_gdr_close)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -543,7 +543,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -622,7 +622,7 @@ BEGIN_GDRCOPY_TEST(invalidation_two_mappings)
         ASSERTDRV(cuMemsetD8(d_A[i], 0x95, size));
     }
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh[2];
@@ -768,7 +768,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -877,7 +877,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_after_gdr_map)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1017,7 +1017,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_map_parent)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1130,7 +1130,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_map_and_free)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1260,7 +1260,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_pin_buffer)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         fd = g->fd;
@@ -1384,7 +1384,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_map)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         print_dbg("%s: Calling gdr_pin_buffer\n", myname);
@@ -1466,7 +1466,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_pin_parent_with_tokens)
         read_fd = filedes_1[0];
         write_fd = filedes_0[1];
 
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         ASSERT_EQ(read(read_fd, &d_A, sizeof(CUdeviceptr)), sizeof(CUdeviceptr));
@@ -1579,7 +1579,7 @@ BEGIN_GDRCOPY_TEST(basic_child_thread_pins_buffer)
     ASSERTDRV(gpuMemAlloc(&t.d_buf, t.size));
     ASSERTDRV(cuMemsetD8(t.d_buf, 0xA5, t.size));
 
-    t.g = gdr_open();
+    t.g = GDR_OPEN_SAFE();
     ASSERT_NEQ(t.g, (void*)0);
     {
         pthread_t tid;


### PR DESCRIPTION
Problems:
- Issue #126.
- In tests (copybw, copylat, sanity), error from gdr_open is detected with assert.
- Most of the time, gdr_open error occurs because gdrdrv is not loaded. However, users most likely cannot guess from the assertion error message.

This PR:
- changes the error message to "gdr_open error: Is gdrdrv driver installed and loaded?". Applied to copybw, copylat, and sanity.

Presubmit testing:
- On gc02 with and without gdrdrv loaded.