### PR TITLE
Fix success/failure summarization in sanity

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -77,8 +77,10 @@ START_TEST(__testname) {                                                \
             print_dbg("&&&& PASSED %s\n", gdrcopy::test::testname);     \
         else if (__child_exit_status == EXIT_WAIVED)                    \
             print_dbg("&&&& WAIVED %s\n", gdrcopy::test::testname);     \
-        else                                                            \
+        else {                                                          \
             print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);     \
+            ck_abort();                                                 \
+        }                                                               \
     }                                                                   \
 } END_TEST
 

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -61,17 +61,17 @@ START_TEST(__testname) {                                                \
     if (__pid < 0) {                                                    \
         print_dbg("Cannot fork\n");                                     \
         print_dbg("&&&& FAILED " # __testname "\n");                    \
-        exit(EXIT_FAILURE);                                             \
+        ck_abort();                                                     \
     }                                                                   \
     if (__pid == 0) {
 
 #define END_GDRCOPY_TEST }                                              \
-    if (__pid) {                                                        \
+    if (__pid > 0) {                                                    \
         int __child_exit_status = -EINVAL;                              \
         if (waitpid(__pid, &__child_exit_status, 0) == -1) {            \
             print_dbg("waitpid returned an error\n");                   \
             print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);     \
-            exit(EXIT_FAILURE);                                         \
+            ck_abort();                                                 \
         }                                                               \
         if (__child_exit_status == EXIT_SUCCESS)                        \
             print_dbg("&&&& PASSED %s\n", gdrcopy::test::testname);     \

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -111,6 +111,15 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
+#define GDR_OPEN_SAFE() ({                                                          \
+        gdr_t _g = gdr_open();                                                      \
+        if (!_g) {                                                                  \
+            fprintf(stderr, "gdr_open error: Is gdrdrv installed and loaded?\n");   \
+            exit(EXIT_FAILURE);                                                     \
+        }                                                                           \
+        _g;                                                                         \
+    })
+
 
 namespace gdrcopy {
     namespace test {

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -111,13 +111,13 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
-#define GDR_OPEN_SAFE() ({                                                          \
-        gdr_t _g = gdr_open();                                                      \
-        if (!_g) {                                                                  \
-            fprintf(stderr, "gdr_open error: Is gdrdrv installed and loaded?\n");   \
-            exit(EXIT_FAILURE);                                                     \
-        }                                                                           \
-        _g;                                                                         \
+#define GDR_OPEN_SAFE() ({                                                              \
+        gdr_t _g = gdr_open();                                                          \
+        if (!_g) {                                                                      \
+            fprintf(stderr, "gdr_open error: Is gdrdrv driver installed and loaded?\n");\
+            exit(EXIT_FAILURE);                                                         \
+        }                                                                               \
+        _g;                                                                             \
     })
 
 

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -144,8 +144,7 @@ int main(int argc, char *argv[])
     ASSERT_NEQ(init_buf, (void*)0);
     init_hbuf_walking_bit(init_buf, size);
 
-    gdr_t g = gdr_open();
-    ASSERT_NEQ(g, (void*)0);
+    gdr_t g = GDR_OPEN_SAFE();
 
     gdr_mh_t mh;
     BEGIN_CHECK {

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
 
     cout << endl;
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -177,7 +177,7 @@ BEGIN_GDRCOPY_TEST(basic)
     CUdeviceptr d_A;
     ASSERTDRV(gpuMemAlloc(&d_A, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -214,7 +214,7 @@ BEGIN_GDRCOPY_TEST(basic_with_tokens)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuPointerGetAttribute(&tokens, CU_POINTER_ATTRIBUTE_P2P_TOKENS, d_A));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh = null_mh;
@@ -272,7 +272,7 @@ BEGIN_GDRCOPY_TEST(basic_unaligned_mapping)
     }
     print_dbg("d_A is unaligned\n");
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     // Try mapping with unaligned address. This should fail.
@@ -354,7 +354,7 @@ BEGIN_GDRCOPY_TEST(data_validation)
     init_hbuf_walking_bit(init_buf, size);
     memset(copy_buf, 0xA5, size * sizeof(*copy_buf));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -467,7 +467,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_gdr_close)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -543,7 +543,7 @@ BEGIN_GDRCOPY_TEST(invalidation_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -622,7 +622,7 @@ BEGIN_GDRCOPY_TEST(invalidation_two_mappings)
         ASSERTDRV(cuMemsetD8(d_A[i], 0x95, size));
     }
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh[2];
@@ -768,7 +768,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_access_after_cumemfree)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -877,7 +877,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_after_gdr_map)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1017,7 +1017,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_map_parent)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1130,7 +1130,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_map_and_free)
     ASSERTDRV(gpuMemAlloc(&d_A, size));
     ASSERTDRV(cuMemsetD8(d_A, 0x95, size));
 
-    gdr_t g = gdr_open();
+    gdr_t g = GDR_OPEN_SAFE();
     ASSERT_NEQ(g, (void*)0);
 
     gdr_mh_t mh;
@@ -1260,7 +1260,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_pin_buffer)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         fd = g->fd;
@@ -1384,7 +1384,7 @@ BEGIN_GDRCOPY_TEST(invalidation_unix_sock_shared_fd_gdr_map)
         close(pair[0]);
 
         print_dbg("%s: Calling gdr_open\n", myname);
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         print_dbg("%s: Calling gdr_pin_buffer\n", myname);
@@ -1466,7 +1466,7 @@ BEGIN_GDRCOPY_TEST(invalidation_fork_child_gdr_pin_parent_with_tokens)
         read_fd = filedes_1[0];
         write_fd = filedes_0[1];
 
-        gdr_t g = gdr_open();
+        gdr_t g = GDR_OPEN_SAFE();
         ASSERT_NEQ(g, (void*)0);
 
         ASSERT_EQ(read(read_fd, &d_A, sizeof(CUdeviceptr)), sizeof(CUdeviceptr));
@@ -1579,7 +1579,7 @@ BEGIN_GDRCOPY_TEST(basic_child_thread_pins_buffer)
     ASSERTDRV(gpuMemAlloc(&t.d_buf, t.size));
     ASSERTDRV(cuMemsetD8(t.d_buf, 0xA5, t.size));
 
-    t.g = gdr_open();
+    t.g = GDR_OPEN_SAFE();
     ASSERT_NEQ(t.g, (void*)0);
     {
         pthread_t tid;


### PR DESCRIPTION
Problems:
- Issue #156, #137, and #126.
- `sanity` always reports success in the summarization line (last line) even with failures.

This PR:
- fixes issue #156, #137, and #126.

Presubmit testing:
- On gc02 with and without gdrdrv installed (simulated success and failure).
- Check output and make sure that it is compatible with DVS format.