### PR TITLE
Support dkms in gdrcopy-kmod.rpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ require CUDA >= 6.0. Additionally, the _sanity_ test requires check >= 0.9.8 and
 subunit.
 
 ```shell
-# On RHEL
-$ sudo yum install check check-devel subunit subunit-devel
+# On RHEL (epel-release repository might be required)
+$ sudo yum install dkms check check-devel subunit subunit-devel
 
 # On Debian
 $ sudo apt install check libsubunit0 libsubunit-dev
@@ -73,8 +73,9 @@ We provide three ways for building and installing GDRCopy
 ### rpm package
 
 ```shell
+# Note: You might need to enable epel-release repository first.
 $ sudo yum groupinstall 'Development Tools'
-$ sudo yum install rpm-build make check check-devel subunit subunit-devel
+$ sudo yum install dkms rpm-build make check check-devel subunit subunit-devel
 $ cd packages
 $ CUDA=<cuda-install-top-dir> ./build-rpm-packages.sh
 $ sudo rpm -Uvh gdrcopy-kmod-<version>.<platform>.rpm

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ require CUDA >= 6.0. Additionally, the _sanity_ test requires check >= 0.9.8 and
 subunit.
 
 ```shell
-# On RHEL (epel-release repository might be required)
+# On RHEL
+# dkms can be installed from epel-release. See https://fedoraproject.org/wiki/EPEL.
 $ sudo yum install dkms check check-devel subunit subunit-devel
 
 # On Debian
@@ -73,7 +74,8 @@ We provide three ways for building and installing GDRCopy
 ### rpm package
 
 ```shell
-# Note: You might need to enable epel-release repository first.
+# dkms can be installed from epel-release. See https://fedoraproject.org/wiki/EPEL.
+
 $ sudo yum groupinstall 'Development Tools'
 $ sudo yum install dkms rpm-build make check check-devel subunit subunit-devel
 $ cd packages

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -39,6 +39,7 @@ if [ "X$VERSION" == "X" ]; then
     echo "Failed to get version numbers!" >&2
     exit 1
 fi
+FULL_VERSION="${VERSION}"
 
 tmpdir=`mktemp -d /tmp/gdr.XXXXXX`
 if [ ! -d "$tmpdir" ]; then
@@ -54,11 +55,13 @@ ex cd ${TOP_DIR_PATH}
 
 ex mkdir -p $tmpdir/gdrcopy
 ex rm -rf $tmpdir/gdrcopy/*
-ex cp -r packages/rhel/init.d insmod.sh Makefile README.md include src tests config_arch LICENSE packages/gdrcopy.spec $tmpdir/gdrcopy/
+ex cp -r packages/dkms.conf packages/rhel/init.d insmod.sh Makefile README.md include src tests config_arch LICENSE packages/gdrcopy.spec $tmpdir/gdrcopy/
 ex rm -f $tmpdir/gdrcopy-$VERSION.tar.gz
 
 ex cd $tmpdir/gdrcopy
+ex find . -type f -exec sed -i "s/@FULL_VERSION@/${FULL_VERSION}/g" {} +
 ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
+ex find . -type f -exec sed -i "s/@MODULE_LOCATION@/${MODULE_SUBDIR//\//\\/}/g" {} +
 
 ex cd $tmpdir
 ex mv gdrcopy gdrcopy-$VERSION

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -2,7 +2,7 @@
 
 # Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
 # See https://rpm-packaging-guide.github.io/#preamble-items
-RPM_VERSION=1
+RPM_VERSION=2
 
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -79,3 +79,7 @@ ex cd ${CWD}
 ex cp $tmpdir/topdir/SRPMS/*.rpm .
 ex cp $tmpdir/topdir/RPMS/*/*.rpm .
 
+echo
+echo "Cleaning up ..."
+
+ex rm -rf ${tmpdir}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -209,7 +209,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
-* Thu Jan 14 2021 Pak Markthub <pmarkthub@nvidia.com> 2.1-2
+* Mon Jan 18 2021 Pak Markthub <pmarkthub@nvidia.com> 2.1-2
 - Add DKMS support in gdrcopy-kmod.rpm
 * Fri Jul 31 2020 Davide Rossetti <drossetti@nvidia.com> 2.1-1
 - fix build problem on RHL8 kernels

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -12,7 +12,7 @@
 
 %global kmod_install_script                                             \
 echo "Start gdrcopy-kmod installation."                                 \
-dkms add -m gdrdrv -v %{version} -q || :                                \
+dkms add -m gdrdrv -v %{version} -q --rpm_safe_upgrade || :             \
                                                                         \
 # Rebuild and make available for all installed kernel                   \
 echo "Building and installing to all available kernels."                \
@@ -123,7 +123,7 @@ fi
 echo "Uninstalling and removing the driver."
 echo "This process may take a few minutes ..."
 dkms uninstall -m gdrdrv -v %{version} -q --all || :
-dkms remove -m gdrdrv -v %{version} -q --all || :
+dkms remove -m gdrdrv -v %{version} -q --all --rpm_safe_upgrade || :
 
 # Clean up the weak-updates symlinks
 find /lib/modules/*/weak-updates -name "gdrdrv.ko.xz" | xargs rm

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -65,7 +65,10 @@ Requires: %{name} = %{version}-%{release}
 %package %{kmod}
 Summary: The kernel-mode driver
 Group: System Environment/Libraries
-Requires: dkms
+Requires: dkms >= 1.00
+Requires: bash
+Release: %{_release}%{?dist}dkms
+BuildArch: noarch
 Recommends: kmod-nvidia-latest-dkms
 
 %description

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -137,6 +137,20 @@ find /lib/modules/*/weak-updates -name "gdrdrv.ko.xz" | xargs rm
 %{kmod_install_script}
 
 
+%triggerin %{kmod} -- kmod-nvidia-latest-dkms
+%{kmod_install_script}
+
+
+%triggerun %{kmod} -- kmod-nvidia-latest-dkms
+# This kmod package has only weak dependency with kmod-nvidia-latest-dkms, which is not enforced by RPM.
+# Uninstalling kmod-nvidia-latest-dkms would not result in uninstalling this package.
+# However, gdrdrv may prevent the removal of nvidia.ko.
+# Hence, we rmmod gdrdrv before starting kmod-nvidia-latest-dkms uninstallation.
+service gdrcopy stop||:
+%{MODPROBE} -rq gdrdrv||:
+service gdrcopy start > /dev/null 2>&1 ||:
+
+
 %clean
 rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 [ "x$RPM_BUILD_ROOT" != "x" ] && rm -rf $RPM_BUILD_ROOT

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -136,7 +136,8 @@ dkms uninstall -m gdrdrv -v %{version} -q --all || :
 dkms remove -m gdrdrv -v %{version} -q --all --rpm_safe_upgrade || :
 
 # Clean up the weak-updates symlinks
-find /lib/modules/*/weak-updates -name "gdrdrv.ko.xz" | xargs rm
+find /lib/modules/*/weak-updates -name "gdrdrv.ko.*" | xargs rm || :
+find /lib/modules/*/weak-updates -name "gdrdrv.ko" | xargs rm || :
 
 
 %postun %{kmod}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -34,6 +34,7 @@ Requires: %{name} = %{version}-%{release}
 Summary: The kernel-mode driver
 Group: System Environment/Libraries
 Requires: dkms
+Recommends: kmod-nvidia-latest-dkms
 
 %description
 GDRCopy, a low-latency GPU memory copy library and a kernel-mode driver, built on top of the 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -61,6 +61,7 @@ AutoReqProv:    no
 Summary: The development files
 Group: System Environment/Libraries
 Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
 
 %package %{kmod}
 Summary: The kernel-mode driver

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -71,6 +71,8 @@ install -m 0755 $RPM_BUILD_DIR/%{name}-%{version}/init.d/gdrcopy $RPM_BUILD_ROOT
 dkms add -m gdrdrv -v %{version} -q || :
 
 # Rebuild and make available for the all installed kernel
+echo "Building and installing to all available kernels."
+echo "This process may take a few minutes ..."
 for kver in $(ls -1d /lib/modules/* | cut -d'/' -f4)
 do
     dkms build -m gdrdrv -v %{version} -k ${kver} -q || :
@@ -97,6 +99,9 @@ if ! ( /sbin/chkconfig --del gdrcopy > /dev/null 2>&1 ); then
 fi              
 
 # Remove all versions from DKMS registry
+echo "Uninstalling and removing the driver."
+echo "This process may take a few minutes ..."
+dkms uninstall -m gdrdrv -v %{version} -q --all || :
 dkms remove -m gdrdrv -v %{version} -q --all || :
 
 %postun %{kmod}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -102,7 +102,7 @@ install -m 0755 $RPM_BUILD_DIR/%{name}-%{version}/init.d/gdrcopy $RPM_BUILD_ROOT
 
 %post %{kmod}
 if [ "$1" == "2" ] && [ -e "%{old_driver_install_dir}/gdrdrv.ko" ]; then
-    echo "Old package detected. Defer installation until after the old package is removed."
+    echo "Old package is detected. Defer installation until after the old package is removed."
 
     # Prevent the uninstall scriptlet of the old package complaining about change in gdrcopy service
     %{daemon_reload_script}
@@ -138,6 +138,10 @@ find /lib/modules/*/weak-updates -name "gdrdrv.ko.xz" | xargs rm
 
 
 %triggerin %{kmod} -- kmod-nvidia-latest-dkms
+if [ "$1" == "2" ] && [ -e "%{old_driver_install_dir}/gdrdrv.ko" ]; then
+    echo "kmod-nvidia-latest-dkms is detected but defer installation because of the old gdrcopy-kmod package."
+    exit 0;
+fi
 %{kmod_install_script}
 
 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -14,7 +14,7 @@
 echo "Start gdrcopy-kmod installation."                                 \
 dkms add -m gdrdrv -v %{version} -q || :                                \
                                                                         \
-# Rebuild and make available for the all installed kernel               \
+# Rebuild and make available for all installed kernel                   \
 echo "Building and installing to all available kernels."                \
 echo "This process may take a few minutes ..."                          \
 for kver in $(ls -1d /lib/modules/* | cut -d'/' -f4)                    \
@@ -92,7 +92,7 @@ make -j CUDA=%{CUDA} config lib exes
 make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} libdir=%{_libdir}
 
 # Install gdrdrv src
-mkdir -p $RPM_BUILD_ROOT/usr/src
+mkdir -p $RPM_BUILD_ROOT%{usr_src_dir}
 cp -r -a $RPM_BUILD_DIR/%{name}-%{version}/src/gdrdrv $RPM_BUILD_ROOT%{usr_src_dir}/gdrdrv-%{version}
 cp -a $RPM_BUILD_DIR/%{name}-%{version}/dkms.conf $RPM_BUILD_ROOT%{usr_src_dir}/gdrdrv-%{version}
 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -55,7 +55,7 @@ Kernel-mode driver for GDRCopy.
 
 %build
 echo "building"
-make -j CUDA=${CUDA}
+make -j CUDA=%{CUDA}
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} libdir=%{_libdir}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -135,6 +135,8 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
+* Thu Jan 14 2021 Pak Markthub <pmarkthub@nvidia.com> 2.1-2
+- Add DKMS support in gdrcopy-kmod.rpm
 * Fri Jul 31 2020 Davide Rossetti <drossetti@nvidia.com> 2.1-1
 - fix build problem on RHL8 kernels
 - relax checks in gdrdrv to support multi-threading use cases


### PR DESCRIPTION
Problems:
- gdrcopy-kmod built with one kernel version cannot be used with others.
- When users upgrade their linux kernel, they have to remake and reinstall gdrcopy-kmod.

This PR:
- modifies the rpm packaging script to support dkms in gdrcopy-kmod.

Presubmitted testing:
- Based environment: CentOS8.2 with linux kernel 4.18.0-193.el8.x86_64. 
- Install gdrcopy-kmod, and then upgrade to linux kernel 4.18.0-240.1.1.el8_3.x86_64. ==> Usable on the new kernel.
- Install the old gdrcopy-kmod package and upgrade to this version. ==> Gracefully clean the previous version.
- Install gdrcopy-kmod and uninstall kmod-nvidia-latest-dkms. ==> kmod-nvidia-latest-dkms can be removed without gdrdrv preventing the uninstallation.
- Install gdrcopy-kmod w/o kmod-nvidia-latest-dkms, then install kmod-nvidia-latest-dkms. ==> gdrdrv becomes available.
   - We have weak dependency with kmod-nvidia-latest-dkms, which is not enforced by RPM. So, users might install gdrcopy-kmod before kmod-nvidia-latest-dkms.