### PR TITLE
Fix kzfree not available in linux kernel 5.10+

### DIFF
--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -392,7 +392,7 @@ static int gdrdrv_release(struct inode *inode, struct file *filp)
         }
         list_del(&mr->node);
         //memset(mr, 0, sizeof(*mr));
-        kzfree(mr);
+        kfree(mr);
     }
     mutex_unlock(&info->lock);
 
@@ -686,7 +686,7 @@ static int gdrdrv_unpin_buffer(gdr_info_t *info, void __user *_params)
         // needed anyway
     }
     //memset(mr, 0, sizeof(*mr));
-    kzfree(mr);
+    kfree(mr);
  out:
     return ret;
 }

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -391,7 +391,7 @@ static int gdrdrv_release(struct inode *inode, struct file *filp)
             mutex_lock(&info->lock);
         }
         list_del(&mr->node);
-        //memset(mr, 0, sizeof(*mr));
+        memset(mr, 0, sizeof(*mr));
         kfree(mr);
     }
     mutex_unlock(&info->lock);
@@ -685,7 +685,7 @@ static int gdrdrv_unpin_buffer(gdr_info_t *info, void __user *_params)
         // not returning an error here because further clean-up is
         // needed anyway
     }
-    //memset(mr, 0, sizeof(*mr));
+    memset(mr, 0, sizeof(*mr));
     kfree(mr);
  out:
     return ret;


### PR DESCRIPTION
Issue:
- See #161.

This PR:
- changes `kzfree` to `kfree`.
- uses `memset` to 0 before calling `kfree(mr)`. 
  - `mr` contains `p2p_token`. Although it is not actually used in recent nvidia driver, users may opt-in to use it. We don't really want this info to leak.