### PR TITLE
Improve copy-to-mapping for small data sizes

### DIFF
--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -558,17 +558,16 @@ static int gdr_copy_to_mapping_internal(void *map_d_ptr, const void *h_ptr, size
         }
 
         // on POWER, compiler/libc memcpy is not optimal for MMIO
-        // 64bit stores are not better than 32bit ones, so we prefer the latter
+        // 64bit stores are not better than 32bit ones, so we prefer the latter.
         // NOTE: if preferred but not aligned, a better implementation would still try to
-        // use byte sized stores to align map_d_ptr and h_ptr to next word
+        // use byte sized stores to align map_d_ptr and h_ptr to next word.
+        // NOTE2: unroll*_memcpy and memcpy do not include fencing. So, we may need the fencing below.
         if (wc_mapping && PREFERS_STORE_UNROLL8 && is_aligned(size, 8) && ptr_is_aligned(map_d_ptr, 8) && ptr_is_aligned(h_ptr, 8)) {
             gdr_dbgc(1, "using unroll8_memcpy for gdr_copy_to_bar\n");
             unroll8_memcpy(map_d_ptr, h_ptr, size);
-            break;
         } else if (wc_mapping && PREFERS_STORE_UNROLL4 && is_aligned(size, 4) && ptr_is_aligned(map_d_ptr, 4) && ptr_is_aligned(h_ptr, 4)) {
             gdr_dbgc(1, "using unroll4_memcpy for gdr_copy_to_bar\n");
             unroll4_memcpy(map_d_ptr, h_ptr, size);
-            break;
         } else {
             gdr_dbgc(1, "fallback to compiler/libc memcpy implementation of gdr_copy_to_bar\n");
             memcpy(map_d_ptr, h_ptr, size);
@@ -616,11 +615,9 @@ static int gdr_copy_from_mapping_internal(void *h_ptr, const void *map_d_ptr, si
         if (wc_mapping && PREFERS_LOAD_UNROLL8 && is_aligned(size, 8) && ptr_is_aligned(map_d_ptr, 8) && ptr_is_aligned(h_ptr, 8)) {
             gdr_dbgc(1, "using unroll8_memcpy for gdr_copy_from_bar\n");
             unroll8_memcpy(h_ptr, map_d_ptr, size);
-            break;
         } else if (wc_mapping && PREFERS_LOAD_UNROLL4 && is_aligned(size, 4) && ptr_is_aligned(map_d_ptr, 4) && ptr_is_aligned(h_ptr, 4)) {
             gdr_dbgc(1, "using unroll4_memcpy for gdr_copy_from_bar\n");
             unroll4_memcpy(h_ptr, map_d_ptr, size);
-            break;
         } else {
             gdr_dbgc(1, "fallback to compiler/libc memcpy implementation of gdr_copy_from_bar\n");
             memcpy(h_ptr, map_d_ptr, size);

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -539,16 +539,16 @@ static int gdr_copy_to_mapping_internal(void *map_d_ptr, const void *h_ptr, size
 {
     do {
         // For very small sizes and aligned pointers, we use simple store.
-        if (size == 1) {
+        if (size == sizeof(uint8_t)) {
             WRITE_ONCE(*(uint8_t *)map_d_ptr, *(uint8_t *)h_ptr);
             goto do_fence;
-        } else if (size == 2 && ptr_is_aligned(map_d_ptr, 2) && ptr_is_aligned(h_ptr, 2)) {
+        } else if (size == sizeof(uint16_t) && ptr_is_aligned(map_d_ptr, sizeof(uint16_t))) {
             WRITE_ONCE(*(uint16_t *)map_d_ptr, *(uint16_t *)h_ptr);
             goto do_fence;
-        } else if (size == 4 && ptr_is_aligned(map_d_ptr, 4) && ptr_is_aligned(h_ptr, 4)) {
+        } else if (size == sizeof(uint32_t) && ptr_is_aligned(map_d_ptr, sizeof(uint32_t))) {
             WRITE_ONCE(*(uint32_t *)map_d_ptr, *(uint32_t *)h_ptr);
             goto do_fence;
-        } else if (size == 8 && ptr_is_aligned(map_d_ptr, 8) && ptr_is_aligned(h_ptr, 8)) {
+        } else if (size == sizeof(uint64_t) && ptr_is_aligned(map_d_ptr, sizeof(uint64_t))) {
             WRITE_ONCE(*(uint64_t *)map_d_ptr, *(uint64_t *)h_ptr);
             goto do_fence;
         }
@@ -572,7 +572,7 @@ static int gdr_copy_to_mapping_internal(void *map_d_ptr, const void *h_ptr, size
         // 64bit stores are not better than 32bit ones, so we prefer the latter.
         // NOTE: if preferred but not aligned, a better implementation would still try to
         // use byte sized stores to align map_d_ptr and h_ptr to next word.
-        // NOTE2: unroll*_memcpy and memcpy do not include fencing. So, we may need the fencing below.
+        // NOTE2: unroll*_memcpy and memcpy do not include fencing.
         if (wc_mapping && PREFERS_STORE_UNROLL8 && is_aligned(size, 8) && ptr_is_aligned(map_d_ptr, 8) && ptr_is_aligned(h_ptr, 8)) {
             gdr_dbgc(1, "using unroll8_memcpy for gdr_copy_to_bar\n");
             unroll8_memcpy(map_d_ptr, h_ptr, size);

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -661,6 +661,8 @@ int gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, s
         gdr_err("mh is not mapped yet\n");
         return EINVAL;
     }
+    if (unlikely(size == 0))
+        return 0;
     return gdr_copy_from_mapping_internal(h_ptr, map_d_ptr, size, mh->wc_mapping);
 }
 

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -645,7 +645,7 @@ static int gdr_copy_from_mapping_internal(void *h_ptr, const void *map_d_ptr, si
 int gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, size_t size)
 {
     gdr_memh_t *mh = to_memh(handle);
-    if (!mh->mapped) {
+    if (unlikely(!mh->mapped)) {
         gdr_err("mh is not mapped yet\n");
         return EINVAL;
     }
@@ -657,7 +657,7 @@ int gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, siz
 int gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, size_t size)
 {
     gdr_memh_t *mh = to_memh(handle);
-    if (!mh->mapped) {
+    if (unlikely(!mh->mapped)) {
         gdr_err("mh is not mapped yet\n");
         return EINVAL;
     }

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -539,9 +539,7 @@ static int gdr_copy_to_mapping_internal(void *map_d_ptr, const void *h_ptr, size
 {
     do {
         // For very small sizes and aligned pointers, we use simple store.
-        if (unlikely(size == 0)) {
-            goto out;
-        } else if (size == 1) {
+        if (size == 1) {
             WRITE_ONCE(*(uint8_t *)map_d_ptr, *(uint8_t *)h_ptr);
             goto do_fence;
         } else if (size == 2 && ptr_is_aligned(map_d_ptr, 2) && ptr_is_aligned(h_ptr, 2)) {
@@ -651,6 +649,8 @@ int gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, siz
         gdr_err("mh is not mapped yet\n");
         return EINVAL;
     }
+    if (unlikely(size == 0))
+        return 0;
     return gdr_copy_to_mapping_internal(map_d_ptr, h_ptr, size, mh->wc_mapping);
 }
 

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -56,13 +56,6 @@
 #define PAGE_SIZE  (1UL << PAGE_SHIFT)
 #define PAGE_MASK  (~(PAGE_SIZE-1))
 
-#ifndef ACCESS_ONCE
-    #define ACCESS_ONCE(x)  (*(volatile typeof(x) *)&x)
-#endif
-#ifndef WRITE_ONCE
-    #define WRITE_ONCE(x, v)    (ACCESS_ONCE(x) = (v))
-#endif
-
 // logging/tracing
 
 enum gdrcopy_msg_level {
@@ -546,7 +539,7 @@ static int gdr_copy_to_mapping_internal(void *map_d_ptr, const void *h_ptr, size
 {
     do {
         // For very small sizes and aligned pointers, we use simple store.
-        if (size == 0) {
+        if (unlikely(size == 0)) {
             goto out;
         } else if (size == 1) {
             WRITE_ONCE(*(uint8_t *)map_d_ptr, *(uint8_t *)h_ptr);

--- a/src/gdrapi_internal.h
+++ b/src/gdrapi_internal.h
@@ -31,6 +31,35 @@
 extern "C" {
 #endif
 
+#ifndef likely
+#ifdef __GNUC__
+#define likely(x)           __builtin_expect(!!(x), 1)
+#else
+#define likely(x)           (x)
+#endif
+#endif
+
+#ifndef unlikely
+#ifdef __GNUC__
+#define unlikely(x)         __builtin_expect(!!(x), 0)
+#else
+#define unlikely(x)         (x)
+#endif
+#endif
+
+#ifndef ACCESS_ONCE
+#define ACCESS_ONCE(x)      (*(volatile typeof(x) *)&x)
+#endif
+
+#ifndef READ_ONCE
+#define READ_ONCE(x)        ACCESS_ONCE(x)
+#endif
+
+#ifndef WRITE_ONCE
+#define WRITE_ONCE(x, v)    (ACCESS_ONCE(x) = (v))
+#endif
+
+
 typedef struct gdr_memh_t { 
     uint32_t handle;
     LIST_ENTRY(gdr_memh_t) entries;

--- a/src/gdrapi_internal.h
+++ b/src/gdrapi_internal.h
@@ -31,14 +31,6 @@
 extern "C" {
 #endif
 
-#ifndef likely
-#ifdef __GNUC__
-#define likely(x)           __builtin_expect(!!(x), 1)
-#else
-#define likely(x)           (x)
-#endif
-#endif
-
 #ifndef unlikely
 #ifdef __GNUC__
 #define unlikely(x)         __builtin_expect(!!(x), 0)
@@ -49,10 +41,6 @@ extern "C" {
 
 #ifndef ACCESS_ONCE
 #define ACCESS_ONCE(x)      (*(volatile typeof(x) *)&x)
-#endif
-
-#ifndef READ_ONCE
-#define READ_ONCE(x)        ACCESS_ONCE(x)
 #endif
 
 #ifndef WRITE_ONCE


### PR DESCRIPTION
Problems:
- Issue #136.
- complex algorithms are used to handle copy-to-mapping for small data sizes.
- `memcpy` sometimes causes double-write to the same memory location.

This PR:
- uses simple store to handle aligned copy-to-mapping of size 1, 2, 4, 8 bytes.
- moves `gdr_init_cpu_flags` calling to `gdr_open`; hence slightly improve the copy performance.
- handles copy size 0. Now, the copy functions become no-op.
- fixes a bug in copy-to-mapping that causes `wc_store_fence` to be skipped when using an `unroll*_copy` algorithm.

Pre-submitted testing
- Note: `numactl` is used to select the nearest numa node.
- Note2: tested with `copylat` only.
- On gc11 (x86-64):
```
>>> MASTER BRANCH
Test                     Size(B)         Avg.Time(us)
gdr_copy_to_mapping             1             0.0909
gdr_copy_to_mapping             2             0.0954
gdr_copy_to_mapping             4             0.0962
gdr_copy_to_mapping             8             0.0954
gdr_copy_to_mapping            16             0.0955
gdr_copy_to_mapping            32             0.0953
gdr_copy_to_mapping            64             0.0962
gdr_copy_to_mapping           128             0.0970
gdr_copy_to_mapping           256             0.1046
gdr_copy_to_mapping           512             0.1259
gdr_copy_to_mapping          1024             0.1696
gdr_copy_to_mapping          2048             0.2549
gdr_copy_to_mapping          4096             0.4269
gdr_copy_to_mapping          8192             0.8140
gdr_copy_to_mapping         16384             1.6042
gdr_copy_to_mapping         32768             3.1915
gdr_copy_to_mapping         65536             6.3758

>>> THIS PR
Test                     Size(B)         Avg.Time(us)
gdr_copy_to_mapping             1             0.0859
gdr_copy_to_mapping             2             0.0842
gdr_copy_to_mapping             4             0.0842
gdr_copy_to_mapping             8             0.0849
gdr_copy_to_mapping            16             0.0880
gdr_copy_to_mapping            32             0.0859
gdr_copy_to_mapping            64             0.0869
gdr_copy_to_mapping           128             0.0931
gdr_copy_to_mapping           256             0.1080
gdr_copy_to_mapping           512             0.1273
gdr_copy_to_mapping          1024             0.1696
gdr_copy_to_mapping          2048             0.2532
gdr_copy_to_mapping          4096             0.4255
gdr_copy_to_mapping          8192             0.8162
gdr_copy_to_mapping         16384             1.5995
gdr_copy_to_mapping         32768             3.1943
gdr_copy_to_mapping         65536             6.3832
```

- On pwr04 (ppc64le):
```
>>> MASTER BRANCH
Test                     Size(B)         Avg.Time(us)
gdr_copy_to_mapping             1             0.0112
gdr_copy_to_mapping             2             0.0137
gdr_copy_to_mapping             4             0.0114
gdr_copy_to_mapping             8             0.0112
gdr_copy_to_mapping            16             0.0130
gdr_copy_to_mapping            32             0.0132
gdr_copy_to_mapping            64             0.0133
gdr_copy_to_mapping           128             0.0157
gdr_copy_to_mapping           256             0.0175
gdr_copy_to_mapping           512             0.0203
gdr_copy_to_mapping          1024             0.0300
gdr_copy_to_mapping          2048             0.0536
gdr_copy_to_mapping          4096             0.1012
gdr_copy_to_mapping          8192             0.2049
gdr_copy_to_mapping         16384             0.3951
gdr_copy_to_mapping         32768             0.8147
gdr_copy_to_mapping         65536             1.6299

>>> THIS PR
Test                     Size(B)         Avg.Time(us)
gdr_copy_to_mapping             1             0.0072
gdr_copy_to_mapping             2             0.0144
gdr_copy_to_mapping             4             0.0073
gdr_copy_to_mapping             8             0.0070
gdr_copy_to_mapping            16             0.0130
gdr_copy_to_mapping            32             0.0114
gdr_copy_to_mapping            64             0.0127
gdr_copy_to_mapping           128             0.0146
gdr_copy_to_mapping           256             0.0147
gdr_copy_to_mapping           512             0.0181
gdr_copy_to_mapping          1024             0.0297
gdr_copy_to_mapping          2048             0.0533
gdr_copy_to_mapping          4096             0.1008
gdr_copy_to_mapping          8192             0.2050
gdr_copy_to_mapping         16384             0.3940
gdr_copy_to_mapping         32768             0.8144
gdr_copy_to_mapping         65536             1.6309
```

- On apollo-11 (arm64):
```
>>> MASTER BRANCH
Test 			 Size(B) 	 Avg.Time(us)
gdr_copy_to_mapping 	        1 	      0.4489
gdr_copy_to_mapping 	        2 	      0.4471
gdr_copy_to_mapping 	        4 	      0.3037
gdr_copy_to_mapping 	        8 	      0.3031
gdr_copy_to_mapping 	       16 	      0.3031
gdr_copy_to_mapping 	       32 	      0.3044
gdr_copy_to_mapping 	       64 	      0.5904
gdr_copy_to_mapping 	      128 	      1.3067
gdr_copy_to_mapping 	      256 	      2.5016
gdr_copy_to_mapping 	      512 	      4.9618
gdr_copy_to_mapping 	     1024 	     10.3988
gdr_copy_to_mapping 	     2048 	     20.6050
gdr_copy_to_mapping 	     4096 	     41.0164
gdr_copy_to_mapping 	     8192 	     81.8798
gdr_copy_to_mapping 	    16384 	    163.4789
gdr_copy_to_mapping 	    32768 	    326.8048
gdr_copy_to_mapping 	    65536 	    653.4606


>>> THIS PR
Test 			 Size(B) 	 Avg.Time(us)
gdr_copy_to_mapping 	        1 	      0.1582
gdr_copy_to_mapping 	        2 	      0.1584
gdr_copy_to_mapping 	        4 	      0.1585
gdr_copy_to_mapping 	        8 	      0.1585
gdr_copy_to_mapping 	       16 	      0.3042
gdr_copy_to_mapping 	       32 	      0.3039
gdr_copy_to_mapping 	       64 	      0.5903
gdr_copy_to_mapping 	      128 	      1.3066
gdr_copy_to_mapping 	      256 	      2.4990
gdr_copy_to_mapping 	      512 	      4.9624
gdr_copy_to_mapping 	     1024 	     10.4001
gdr_copy_to_mapping 	     2048 	     20.6096
gdr_copy_to_mapping 	     4096 	     41.0165
gdr_copy_to_mapping 	     8192 	     81.8729
gdr_copy_to_mapping 	    16384 	    163.4748
gdr_copy_to_mapping 	    32768 	    326.8132
gdr_copy_to_mapping 	    65536 	    653.7387
```