### PR TITLE
Support automated build on the internal system

### DIFF
--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -98,12 +98,15 @@ ex mv gdrcopy gdrcopy-${VERSION}
 ex tar czvf gdrcopy_${VERSION}.orig.tar.gz gdrcopy-${VERSION}
 
 ex cd ${tmpdir}/gdrcopy-${VERSION}
+debuild_params="--set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
 if [ "${skip_dep_check}" -eq 1 ]; then
-    echo "Skip build dependency check. Use the environment variables ..."
-    ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} --set-envvar=C_INCLUDE_PATH=${C_INCLUDE_PATH} --set-envvar=CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH} --set-envvar=LIBRARY_PATH=${LIBRARY_PATH} --set-envvar=LD_LIBRARY_PATH=${LD_LIBRARY_PATH} -us -uc -d
-else
-    ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} -us -uc
+    debuild_params+=" --set-envvar=C_INCLUDE_PATH=${C_INCLUDE_PATH} --set-envvar=CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH} --set-envvar=LIBRARY_PATH=${LIBRARY_PATH} --set-envvar=LD_LIBRARY_PATH=${LD_LIBRARY_PATH} -d"
+    echo "Skip build dependency check. Use the environment variables instead ..."
 fi
+# --set-envvar needs to be placed before -us -uc
+debuild_params+=" -us -uc"
+ex debuild ${debuild_params}
+
 
 echo
 echo "Building dkms module ..."

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -9,6 +9,8 @@ TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."
 
 CWD=$(pwd)
 
+skip_dep_check=0
+
 ex()
 {
     local rc
@@ -21,6 +23,33 @@ ex()
         exit $rc
     fi
 }
+
+function show_help
+{
+    echo "Usage: [CUDA=<path>] $0 [-d] [-h]"
+    echo ""
+    echo "  CUDA=<path>     Set your installed CUDA path (ex. /usr/local/cuda)."
+    echo "  -d              Don't check build dependencies. Use my environment variables such as C_INCLUDE_PATH instead."
+    echo "  -h              Show this help text."
+    echo ""
+}
+
+OPTIND=1	# Reset in case getopts has been used previously in the shell.
+
+while getopts "hd" opt; do
+    case "${opt}" in
+    h)
+        show_help
+        exit 0
+        ;;
+    d)  skip_dep_check=1
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+
 
 if [ "X$CUDA" == "X" ]; then
     echo "CUDA environment variable is not defined"; exit 1
@@ -69,7 +98,12 @@ ex mv gdrcopy gdrcopy-${VERSION}
 ex tar czvf gdrcopy_${VERSION}.orig.tar.gz gdrcopy-${VERSION}
 
 ex cd ${tmpdir}/gdrcopy-${VERSION}
-ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} -us -uc
+if [ "${skip_dep_check}" -eq 1 ]; then
+    echo "Skip build dependency check. Use the environment variables ..."
+    ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} --set-envvar=C_INCLUDE_PATH=${C_INCLUDE_PATH} --set-envvar=CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH} --set-envvar=LIBRARY_PATH=${LIBRARY_PATH} --set-envvar=LD_LIBRARY_PATH=${LD_LIBRARY_PATH} -us -uc -d
+else
+    ex debuild --set-envvar=CUDA=${CUDA} --set-envvar=PKG_CONFIG_PATH=${PKG_CONFIG_PATH} -us -uc
+fi
 
 echo
 echo "Building dkms module ..."

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -71,7 +71,7 @@ Requires: bash
 Release: %{_release}%{?dist}dkms
 BuildArch: noarch
 %if 0%{?rhel} >= 8
-# Recommends tag is a weak dependency, which is started supporting in RHEL8.
+# Recommends tag is a weak dependency, whose support started in RHEL8.
 # See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software#support-for-weak-dependencies_new-features-in-rhel-8.
 Recommends: kmod-nvidia-latest-dkms
 %endif

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -70,7 +70,11 @@ Requires: dkms >= 1.00
 Requires: bash
 Release: %{_release}%{?dist}dkms
 BuildArch: noarch
+%if 0%{?rhel} >= 8
+# Recommends tag is a weak dependency, which is started supporting in RHEL8.
+# See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software#support-for-weak-dependencies_new-features-in-rhel-8.
 Recommends: kmod-nvidia-latest-dkms
+%endif
 
 %description
 GDRCopy, a low-latency GPU memory copy library and a kernel-mode driver, built on top of the 


### PR DESCRIPTION
Problems:
- Issue #168.
- Systems that do not have build dependencies installed (libcheck, etc.) via dpkg cannot build the deb packages.

This PR:
- adds `Recommends` tag on RHEL8 or later only because weak dependencies tags are supported from RHEL8. See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software#support-for-weak-dependencies_new-features-in-rhel-8.
- adds `-d` option to `build-deb-packages.sh`. It allows the script to skip build dependencies check and uses environment variables instead. Users can locally compile and install libcheck, libsubunit, etc. and point the environment variables to those directories before launching `build-deb-packages.sh`.