### PR TITLE
Suppress warning messages in gdrcopy-kmod.rpm

### DIFF
--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -140,8 +140,8 @@ dkms uninstall -m gdrdrv -v %{version} -q --all || :
 dkms remove -m gdrdrv -v %{version} -q --all --rpm_safe_upgrade || :
 
 # Clean up the weak-updates symlinks
-find /lib/modules/*/weak-updates -name "gdrdrv.ko.*" | xargs rm || :
-find /lib/modules/*/weak-updates -name "gdrdrv.ko" | xargs rm || :
+find /lib/modules/*/weak-updates -name "gdrdrv.ko.*" -delete &> /dev/null || :
+find /lib/modules/*/weak-updates -name "gdrdrv.ko" -delete &> /dev/null || :
 
 
 %postun %{kmod}

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -23,7 +23,7 @@ do                                                                      \
     dkms install -m gdrdrv -v %{version} -k ${kver} -q --force || :     \
 done                                                                    \
                                                                         \
-/sbin/depmod -a %{KVERSION}                                             \
+/sbin/depmod -a %{KVERSION} &> /dev/null ||:                            \
 %{MODPROBE} -rq gdrdrv||:                                               \
 %{MODPROBE} gdrdrv||:                                                   \
                                                                         \


### PR DESCRIPTION
Issue: #173.

This PR:
- redirects messages from depmod to /dev/null.
- changes symlink deletion from `rm` to `find -delete`.
- silence messages from `find`.

Pre-submitted testings:
- On RHEL7.

Before
```
$ sudo rpm -e gdrcopy gdrcopy-kmod 
Stopping gdrcopy (via systemctl):                          [  OK  ]
Stopping gdrcopy (via systemctl):                          [  OK  ]
Uninstalling and removing the driver.
This process may take a few minutes ...
rm: missing operand
Try 'rm --help' for more information.
```

After
```
$ sudo rpm -e gdrcopy-kmod 
Stopping gdrcopy (via systemctl):                          [  OK  ]
Stopping gdrcopy (via systemctl):                          [  OK  ]
Uninstalling and removing the driver.
This process may take a few minutes ...
```
