### PR TITLE
Use PAGE_SIZE from sysconf

### DIFF
--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -47,7 +47,6 @@
 #include "gdrdrv.h"
 #include "gdrapi_internal.h"
 
-// TODO either use page_size = sysconf(_SC_PAGESIZE) or check the assumption below
 static int    PAGE_SHIFT = -1;
 static size_t PAGE_SIZE = 0;
 static size_t PAGE_MASK = 0;
@@ -121,7 +120,7 @@ gdr_t gdr_open()
         PAGE_MASK = PAGE_SIZE - 1;
 
         size_t ps_tmp = PAGE_SIZE;
-        PAGE_SHIFT = 0;
+        PAGE_SHIFT = -1;
         while (ps_tmp > 0) {
             ++PAGE_SHIFT;
             if (ps_tmp & 0x1 == 1)

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -117,7 +117,7 @@ gdr_t gdr_open()
     // Initialize PAGE_SHIFT, PAGE_SIZE, and PAGE_MASK.
     if (!gdr_is_initialized()) {
         PAGE_SIZE = sysconf(_SC_PAGESIZE);
-        PAGE_MASK = PAGE_SIZE - 1;
+        PAGE_MASK = ~(PAGE_SIZE - 1);
 
         size_t ps_tmp = PAGE_SIZE;
         PAGE_SHIFT = -1;

--- a/src/gdrapi_internal.h
+++ b/src/gdrapi_internal.h
@@ -58,6 +58,9 @@ typedef struct gdr_memh_t {
 struct gdr {
     int fd;
     LIST_HEAD(memh_list, gdr_memh_t) memhs;
+    size_t page_size;
+    size_t page_mask;
+    uint8_t page_shift;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Issue:
- See #176.

This PR:
- removes static definition of PAGE_SIZE, PAGE_MASK, and PAGE_SHIFT.
- defines page_size, page_mask, and page_shift in struct gdr (internal data structure).
- queries page_size from sysconf and calculates page_mask and page_shift in gdr_open.

Pre-submit testing:
- locally on x86_64 and aarch64.
- on internal testing system for x86_64, ppc64le, aarch64. See the internal bug for details.

