### PR TITLE
Update Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,7 @@ LDFLAGS  := $(CUDA_LIB) -L $(CUDA)/lib64 -L $(GDRAPI_SRC)
 COMMONCFLAGS := -O2
 CFLAGS   += $(COMMONCFLAGS)
 CXXFLAGS += $(COMMONCFLAGS)
-LIBS     := -lcuda -lpthread -ldl -lgdrapi
+LIBS     := -lcuda -lpthread -ldl -lgdrapi -lcheck
 
 SRCS := copybw.cpp sanity.cpp copylat.cpp
 EXES := $(SRCS:.cpp=)


### PR DESCRIPTION
This fixes a problem with some RHEL 8 machines, where libcheck is compiled from source.