### PR TITLE
Fix incorrect info in Provides section in rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install: lib_install exes_install
 lib_install: lib
 	@ echo "installing in $(DESTLIB) $(DESTINC)..." && \
 	mkdir -p $(DESTLIB) && \
-	install -D -v -m u=rw,g=rw,o=r src/$(LIB_DYNAMIC) -t $(DESTLIB) && \
+	install -D -v -m u=rwx,g=rx,o=rx src/$(LIB_DYNAMIC) -t $(DESTLIB) && \
 	mkdir -p $(DESTINC) && \
 	install -D -v -m u=rw,g=rw,o=r include/* -t $(DESTINC); \
 	cd $(DESTLIB); \

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -54,9 +54,6 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  gcc kernel-headers check-devel
 Requires:       %{name}-%{kmod} check
 
-# to get rid of libcuda/libcudart
-AutoReqProv:    no
-
 %package devel
 Summary: The development files
 Group: System Environment/Libraries

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -41,6 +41,7 @@ if [ -e /usr/bin/systemctl ]; then                                      \
     /usr/bin/systemctl daemon-reload                                    \
 fi
 
+%global __requires_exclude ^libcuda\\.so.*$
 
 
 Name:           gdrcopy


### PR DESCRIPTION
Problems:
- See issue #180.

Root cause:
- The permission of libgdrapi.so.* is not set as executable when install. RPM does not pick non-executable libraries as Provides.
- AutoReqProv is set to "no" in gdrcopy.spec. This prevents Provides section generation. 
  @drossetti You left a comment `to get rid of libcuda/libcudart`. However, I don't observe that issue when I remove that line. Can you confirm?

This PR:
- changes permission of installed libgdrapi.so to 755.
- removes `AutoReqProv: no` from gdrcopy.spec.

Pre-submit testing:
- locally on RHEL8.3. Now, the package looks like
```
$ rpm -qp --provides gdrcopy-2.2-1.x86_64.rpm 
gdrcopy = 2.2-1
gdrcopy(x86-64) = 2.2-1
libgdrapi.so.2()(64bit)
```
