### PR TITLE
Print more meaningful error messages in copybw and copylat when gdr_pin_buffer fails

### DIFF
--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <map>
-#include <iostream>
 #include <cuda.h>
 #include "common.hpp"
 
@@ -48,7 +47,7 @@ namespace gdrcopy {
         {
             int diff = 0;
             if (size % 4 != 0U) {
-                printf("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
+                print_dbg("warning: buffer size %zu is not dword aligned, ignoring trailing bytes\n", size);
                 size -= (size % 4);
             }
             unsigned ndwords = size/sizeof(uint32_t);
@@ -64,7 +63,7 @@ namespace gdrcopy {
                 }
             }
             if (diff) {
-                printf("check error: %d different dwords out of %d\n", diff, ndwords);
+                print_dbg("check error: %d different dwords out of %d\n", diff, ndwords);
             }
             return diff;
         }
@@ -103,7 +102,7 @@ namespace gdrcopy {
                 ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
 
                 if (!gdr_support)
-                    std::cerr << "This GPU does not support GPUDirect RDMA." << std::endl;
+                    print_dbg("This GPU does not support GPUDirect RDMA.\n");
 
                 return !!gdr_support;
             }
@@ -119,8 +118,8 @@ namespace gdrcopy {
             gdr_mh_t mh;
             int status = gdr_pin_buffer(g, d_A, size, 0, 0, &mh);
             if (status != 0) {
-                std::cerr << "error in gdr_pin_buffer with code=" << status << std::endl;
-                std::cerr << "Your GPU might not support GPUDirect RDMA" << std::endl;
+                print_dbg("error in gdr_pin_buffer with code=%d\n", status);
+                print_dbg("Your GPU might not support GPUDirect RDMA\n");
             }
             else
                 ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -25,6 +25,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <map>
+#include <iostream>
+#include <cuda.h>
 #include "common.hpp"
 
 namespace gdrcopy {
@@ -87,6 +89,47 @@ namespace gdrcopy {
             //OUT << "filling mem with walking bit " << endl;
             for(w = 0; w<size/sizeof(uint32_t); ++w)
                 h_buf[w] = w;
+        }
+
+        bool check_gdr_support(CUdevice dev)
+        {
+            #if CUDA_VERSION >= 11030
+            int drv_version;
+            ASSERTDRV(cuDriverGetVersion(&drv_version));
+
+            // Starting from CUDA 11.3, CUDA provides an ability to check GPUDirect RDMA support.
+            if (drv_version >= 11030) {
+                int gdr_support = 0;
+                ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
+
+                if (!gdr_support)
+                    std::cerr << "This GPU does not support GPUDirect RDMA." << std::endl;
+
+                return !!gdr_support;
+            }
+            #endif
+
+            // For older versions, we fall back to detect this support with gdr_pin_buffer.
+            const size_t size = GPU_PAGE_SIZE;
+            CUdeviceptr d_A;
+            ASSERTDRV(gpuMemAlloc(&d_A, size));
+
+            gdr_t g = gdr_open_safe();
+
+            gdr_mh_t mh;
+            int status = gdr_pin_buffer(g, d_A, size, 0, 0, &mh);
+            if (status != 0) {
+                std::cerr << "error in gdr_pin_buffer with code=" << status << std::endl;
+                std::cerr << "Your GPU might not support GPUDirect RDMA" << std::endl;
+            }
+            else
+                ASSERT_EQ(gdr_unpin_buffer(g, mh), 0);
+
+            ASSERT_EQ(gdr_close(g), 0);
+
+            ASSERTDRV(gpuMemFree(d_A));
+
+            return status == 0;
         }
     }
 }

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -197,5 +197,7 @@ namespace gdrcopy {
         void init_hbuf_walking_bit(uint32_t *h_buf, size_t size);
 
         void init_hbuf_linear_ramp(uint32_t *h_buf, size_t size);
+
+        bool check_gdr_support(CUdevice dev);
     }
 }

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -130,6 +130,25 @@ int main(int argc, char *argv[])
     cout << "selecting device " << dev_id << endl;
     ASSERTDRV(cuDeviceGet(&dev, dev_id));
 
+    #if CUDA_VERSION >= 11030
+    int drv_version;
+    ASSERTDRV(cuDriverGetVersion(&drv_version));
+
+    // Starting from CUDA 11.3, CUDA provides an ability to check GPUDirect RDMA support.
+    if (drv_version >= 11030) {
+        int gdr_support = 0;
+        ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
+
+        if (!gdr_support)
+            cerr << "This GPU does not support GPUDirect RDMA." << endl;
+
+        ASSERT_NEQ(gdr_support, 0);
+    }
+
+    // For older versions, we fall back to detect this support when calling gdr_pin_buffer.
+    #endif
+
+
     CUcontext dev_ctx;
     ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
     ASSERTDRV(cuCtxSetCurrent(dev_ctx));

--- a/tests/copybw.cpp
+++ b/tests/copybw.cpp
@@ -42,6 +42,8 @@ int num_read_iters  = 100;
 
 int main(int argc, char *argv[])
 {
+    int status = 0;
+
     size_t _size = 128*1024;
     size_t copy_size = 0;
     size_t copy_offset = 0;
@@ -149,8 +151,12 @@ int main(int argc, char *argv[])
     gdr_mh_t mh;
     BEGIN_CHECK {
         // tokens are optional in CUDA 6.0
-        // wave out the test if GPUDirectRDMA is not enabled
-        BREAK_IF_NEQ(gdr_pin_buffer(g, d_A, size, 0, 0, &mh), 0);
+        status = gdr_pin_buffer(g, d_A, size, 0, 0, &mh);
+        if (status != 0) {
+            cerr << "error in gdr_pin_buffer with code=" << status << endl;
+            cerr << "Does the selected GPU support GPUDirect RDMA?" << endl;
+        }
+        ASSERT_EQ(status, 0);
         ASSERT_NEQ(mh, null_mh);
 
         void *map_d_ptr  = NULL;

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -43,6 +43,8 @@ int num_read_iters = 100;
 
 int main(int argc, char *argv[])
 {
+    int status = 0;
+
     size_t _size = (size_t)1 << 24;
     size_t copy_size = 1;
     int dev_id = 0;
@@ -184,8 +186,12 @@ int main(int argc, char *argv[])
     gdr_mh_t mh;
     BEGIN_CHECK {
         // tokens are optional in CUDA 6.0
-        // wave out the test if GPUDirectRDMA is not enabled
-        BREAK_IF_NEQ(gdr_pin_buffer(g, d_A, size, 0, 0, &mh), 0);
+        status = gdr_pin_buffer(g, d_A, size, 0, 0, &mh);
+        if (status != 0) {
+            cerr << "error in gdr_pin_buffer with code=" << status << endl;
+            cerr << "Does the selected GPU support GPUDirect RDMA?" << endl;
+        }
+        ASSERT_EQ(status, 0);
         ASSERT_NEQ(mh, null_mh);
 
         void *map_d_ptr  = NULL;

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -117,6 +117,24 @@ int main(int argc, char *argv[])
     cout << "selecting device " << dev_id << endl;
     ASSERTDRV(cuDeviceGet(&dev, dev_id));
 
+    #if CUDA_VERSION >= 11030
+    int drv_version;
+    ASSERTDRV(cuDriverGetVersion(&drv_version));
+
+    // Starting from CUDA 11.3, CUDA provides an ability to check GPUDirect RDMA support.
+    if (drv_version >= 11030) {
+        int gdr_support = 0;
+        ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
+
+        if (!gdr_support)
+            cerr << "This GPU does not support GPUDirect RDMA." << endl;
+
+        ASSERT_NEQ(gdr_support, 0);
+    }
+
+    // For older versions, we fall back to detect this support when calling gdr_pin_buffer.
+    #endif
+
     CUcontext dev_ctx;
     ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
     ASSERTDRV(cuCtxSetCurrent(dev_ctx));

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -43,8 +43,6 @@ int num_read_iters = 100;
 
 int main(int argc, char *argv[])
 {
-    int status = 0;
-
     size_t _size = (size_t)1 << 24;
     size_t copy_size = 1;
     int dev_id = 0;
@@ -117,27 +115,11 @@ int main(int argc, char *argv[])
     cout << "selecting device " << dev_id << endl;
     ASSERTDRV(cuDeviceGet(&dev, dev_id));
 
-    #if CUDA_VERSION >= 11030
-    int drv_version;
-    ASSERTDRV(cuDriverGetVersion(&drv_version));
-
-    // Starting from CUDA 11.3, CUDA provides an ability to check GPUDirect RDMA support.
-    if (drv_version >= 11030) {
-        int gdr_support = 0;
-        ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
-
-        if (!gdr_support)
-            cerr << "This GPU does not support GPUDirect RDMA." << endl;
-
-        ASSERT_NEQ(gdr_support, 0);
-    }
-
-    // For older versions, we fall back to detect this support when calling gdr_pin_buffer.
-    #endif
-
     CUcontext dev_ctx;
     ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
     ASSERTDRV(cuCtxSetCurrent(dev_ctx));
+
+    ASSERT_EQ(check_gdr_support(dev), true);
 
     CUdeviceptr d_A;
     ASSERTDRV(cuMemAlloc(&d_A, size));
@@ -204,12 +186,7 @@ int main(int argc, char *argv[])
     gdr_mh_t mh;
     BEGIN_CHECK {
         // tokens are optional in CUDA 6.0
-        status = gdr_pin_buffer(g, d_A, size, 0, 0, &mh);
-        if (status != 0) {
-            cerr << "error in gdr_pin_buffer with code=" << status << endl;
-            cerr << "Does the selected GPU support GPUDirect RDMA?" << endl;
-        }
-        ASSERT_EQ(status, 0);
+        ASSERT_EQ(gdr_pin_buffer(g, d_A, size, 0, 0, &mh), 0);
         ASSERT_NEQ(mh, null_mh);
 
         void *map_d_ptr  = NULL;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -65,26 +65,10 @@ static void init_cuda(int dev_id)
     ASSERTDRV(cuInit(0));
     ASSERTDRV(cuDeviceGet(&dev, dev_id));
 
-    #if CUDA_VERSION >= 11030
-    int drv_version;
-    ASSERTDRV(cuDriverGetVersion(&drv_version));
-
-    // Starting from CUDA 11.3, CUDA provides an ability to check GPUDirect RDMA support.
-    if (drv_version >= 11030) {
-        int gdr_support = 0;
-        ASSERTDRV(cuDeviceGetAttribute(&gdr_support, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, dev));
-
-        if (!gdr_support)
-            cerr << "This GPU (GPU ID: " << dev_id << ") does not support GPUDirect RDMA." << endl;
-
-        ASSERT_NEQ(gdr_support, 0);
-    }
-
-    // For older versions, we fall back to detect this support when calling gdr_pin_buffer.
-    #endif
-
     ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
     ASSERTDRV(cuCtxSetCurrent(dev_ctx));
+
+    ASSERT_EQ(check_gdr_support(dev), true);
 }
 
 static void finalize_cuda(int dev_id)


### PR DESCRIPTION
Issue:
- See #165 and #189.
- copybw and copylat silently fail when running on GPU that doesn't support GPUDirect RDMA.

This PR:
- modifies copybw and copylat to print meaningful error messages when gdr_pin_buffer fails.

Presubmit testing:
- On GeForce RTX 2070

```
$ LD_LIBRARY_PATH=../src/:$LD_LIBRARY_PATH ./copylat
GPU id:0; name: GeForce RTX 2070; Bus id: 0000:01:00
selecting device 0
device ptr: 0x7f47ff000000
allocated size: 16777216

error in gdr_pin_buffer with code=22
Does the selected GPU support GPUDirect RDMA?
Assertion "(status) == (0)" failed at copylat.cpp:195
```