### PR TITLE
Add cuMemCreate support to tests

### DIFF
--- a/tests/apiperf.cpp
+++ b/tests/apiperf.cpp
@@ -41,13 +41,27 @@ using namespace gdrcopy::test;
 int num_iters        = 100;
 int num_bins         = 10;
 int num_warmup_iters = 10;
+size_t _size = (size_t)1 << 24;
+int dev_id = 0;
 
-int main(int argc, char *argv[])
+void print_usage(const char *path)
 {
-    size_t _size = (size_t)1 << 24;
+    cout << "Usage: " << path << " [-h][-s <max-size>][-d <gpu>][-n <iters>][-w <iters>][-a <fn>]" << endl;
+    cout << endl;
+    cout << "Options:" << endl;
+    cout << "   -h              Print this help text" << endl;
+    cout << "   -s <max-size>   Max buffer size to benchmark (default: " << _size << ")" << endl;
+    cout << "   -d <gpu>        GPU ID (default: " << dev_id << ")" << endl;
+    cout << "   -n <iters>      Number of benchmark iterations (default: " << num_iters << ")" << endl;
+    cout << "   -w <iters>      Number of warm-up iterations (default: " << num_warmup_iters << ")" << endl;
+    cout << "   -a <fn>         GPU buffer allocation function (default: cuMemAlloc)" << endl;
+    cout << "                       Choices: cuMemAlloc, cuMemCreate" << endl;
+}
+
+void run_test(CUdeviceptr d_A, size_t size)
+{
     // minimum pinning size is a GPU page size
     size_t pin_request_size = GPU_PAGE_SIZE;
-    int dev_id = 0;
     struct timespec beg, end;
     double pin_lat_us;
     double map_lat_us;
@@ -57,82 +71,6 @@ int main(int argc, char *argv[])
     double delta_lat_us;
     double *lat_arr;
     int *bin_arr;
-
-    while(1) {
-        int c;
-        c = getopt(argc, argv, "s:d:n:w:h");
-        if (c == -1)
-            break;
-
-        switch (c) {
-            case 's':
-                _size = strtol(optarg, NULL, 0);
-                break;
-            case 'd':
-                dev_id = strtol(optarg, NULL, 0);
-                break;
-            case 'n':
-                num_iters = strtol(optarg, NULL, 0);
-                break;
-            case 'w':
-                num_warmup_iters = strtol(optarg, NULL, 0);
-                break;
-            case 'h':
-                printf("syntax: %s -s <max buf size> -d <gpu dev id> -n <num iters> -w <warmup iters> -h[help]\n", argv[0]);
-                exit(EXIT_FAILURE);
-                break;
-            default:
-                printf("ERROR: invalid option\n");
-                exit(EXIT_FAILURE);
-        }
-    }
-
-    size_t size = (_size + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
-
-    ASSERTDRV(cuInit(0));
-
-    int n_devices = 0;
-    ASSERTDRV(cuDeviceGetCount(&n_devices));
-
-    CUdevice dev;
-    for (int n=0; n<n_devices; ++n) {
-
-        char dev_name[256];
-        int dev_pci_domain_id;
-        int dev_pci_bus_id;
-        int dev_pci_device_id;
-
-        ASSERTDRV(cuDeviceGet(&dev, n));
-        ASSERTDRV(cuDeviceGetName(dev_name, sizeof(dev_name) / sizeof(dev_name[0]), dev));
-        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_domain_id, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, dev));
-        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_bus_id, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, dev));
-        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_device_id, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, dev));
-
-        cout  << "GPU id:" << n << "; name: " << dev_name
-              << "; Bus id: "
-              << std::hex
-              << std::setfill('0') << std::setw(4) << dev_pci_domain_id
-              << ":" << std::setfill('0') << std::setw(2) << dev_pci_bus_id
-              << ":" << std::setfill('0') << std::setw(2) << dev_pci_device_id
-              << std::dec
-              << endl;
-    }
-    cout << "selecting device " << dev_id << endl;
-    ASSERTDRV(cuDeviceGet(&dev, dev_id));
-
-    CUcontext dev_ctx;
-    ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
-    ASSERTDRV(cuCtxSetCurrent(dev_ctx));
-
-    CUdeviceptr d_A;
-    gpu_mem_handle_t mhandle;
-    ASSERTDRV(gpu_mem_alloc(&mhandle, size, true, true));
-    d_A = mhandle.ptr;
-    cout << "device ptr: 0x" << hex << d_A << dec << endl;
-    cout << "allocated size: " << size << endl;
-
-    unsigned int flag = 1;
-    ASSERTDRV(cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, d_A));
 
     gdr_t g = gdr_open();
     ASSERT_NEQ(g, (void*)0);
@@ -224,6 +162,7 @@ int main(int argc, char *argv[])
 
             printf("Histogram of gdr_pin_buffer latency for %ld bytes\n", actual_pin_size);
             print_histogram(lat_arr, num_iters, bin_arr, num_bins, min_lat, max_lat);
+            printf("\n");
         }
 
         free(lat_arr);
@@ -233,7 +172,105 @@ int main(int argc, char *argv[])
     cout << "closing gdrdrv" << endl;
     ASSERT_EQ(gdr_close(g), 0);
 
-    ASSERTDRV(gpu_mem_free(&mhandle));
+}
+
+int main(int argc, char *argv[])
+{
+    gpu_memalloc_fn_t galloc_fn = gpu_mem_alloc;
+    gpu_memfree_fn_t gfree_fn = gpu_mem_free;
+
+    while(1) {
+        int c;
+        c = getopt(argc, argv, "s:d:n:w:a:h");
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 's':
+                _size = strtol(optarg, NULL, 0);
+                break;
+            case 'd':
+                dev_id = strtol(optarg, NULL, 0);
+                break;
+            case 'n':
+                num_iters = strtol(optarg, NULL, 0);
+                break;
+            case 'w':
+                num_warmup_iters = strtol(optarg, NULL, 0);
+                break;
+            case 'a':
+                if (strcmp(optarg, "cuMemAlloc") == 0) {
+                    galloc_fn = gpu_mem_alloc;
+                    gfree_fn = gpu_mem_free;
+                }
+                else if (strcmp(optarg, "cuMemCreate") == 0) {
+                    galloc_fn = gpu_vmm_alloc;
+                    gfree_fn = gpu_vmm_free;
+                }
+                else {
+                    cerr << "Unrecognized fn argument" << endl;
+                    exit(EXIT_FAILURE);
+                }
+                break;
+            case 'h':
+                print_usage(argv[0]);
+                exit(EXIT_SUCCESS);
+                break;
+            default:
+                printf("ERROR: invalid option\n");
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    size_t size = (_size + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
+
+    ASSERTDRV(cuInit(0));
+
+    int n_devices = 0;
+    ASSERTDRV(cuDeviceGetCount(&n_devices));
+
+    CUdevice dev;
+    for (int n=0; n<n_devices; ++n) {
+
+        char dev_name[256];
+        int dev_pci_domain_id;
+        int dev_pci_bus_id;
+        int dev_pci_device_id;
+
+        ASSERTDRV(cuDeviceGet(&dev, n));
+        ASSERTDRV(cuDeviceGetName(dev_name, sizeof(dev_name) / sizeof(dev_name[0]), dev));
+        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_domain_id, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, dev));
+        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_bus_id, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, dev));
+        ASSERTDRV(cuDeviceGetAttribute(&dev_pci_device_id, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, dev));
+
+        cout  << "GPU id:" << n << "; name: " << dev_name
+              << "; Bus id: "
+              << std::hex
+              << std::setfill('0') << std::setw(4) << dev_pci_domain_id
+              << ":" << std::setfill('0') << std::setw(2) << dev_pci_bus_id
+              << ":" << std::setfill('0') << std::setw(2) << dev_pci_device_id
+              << std::dec
+              << endl;
+    }
+    cout << "selecting device " << dev_id << endl;
+    ASSERTDRV(cuDeviceGet(&dev, dev_id));
+
+    CUcontext dev_ctx;
+    ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
+    ASSERTDRV(cuCtxSetCurrent(dev_ctx));
+
+    ASSERT_EQ(check_gdr_support(dev), true);
+
+    CUdeviceptr d_A;
+    gpu_mem_handle_t mhandle;
+    ASSERTDRV(galloc_fn(&mhandle, size, true, true));
+    d_A = mhandle.ptr;
+    cout << "device ptr: 0x" << hex << d_A << dec << endl;
+    cout << "allocated size: " << size << endl;
+
+    run_test(d_A, size);
+
+    ASSERTDRV(gfree_fn(&mhandle));
 
     ASSERTDRV(cuCtxSetCurrent(NULL));
     ASSERTDRV(cuDevicePrimaryCtxRelease(dev));

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -346,7 +346,9 @@ out:
         void print_histogram(double *lat_arr, int count, int *bin_arr, int num_bins, double min, double max)
         {
             int den = (max - min) / num_bins;
-            for (int j = 0; j < num_bins; j++) bin_arr[j] = 0;
+            den = den > 0 ? den : 1;
+            for (int j = 0; j < num_bins; j++) 
+                bin_arr[j] = 0;
             for (int i = 0; i < count; i++) {
                 bin_arr[(int) ((lat_arr[i] - min) / den)]++;
             }

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -43,7 +43,7 @@ namespace gdrcopy {
             }
         }
 
-        CUresult gpu_mem_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_mem_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops)
         {
             CUresult ret = CUDA_SUCCESS;
             CUdeviceptr ptr, out_ptr;
@@ -80,7 +80,7 @@ namespace gdrcopy {
             return CUDA_SUCCESS;
         }
 
-        CUresult gpu_mem_free(gpu_mem_handle_t *handle);
+        CUresult gpu_mem_free(gpu_mem_handle_t *handle)
         {
             CUresult ret = CUDA_SUCCESS;
             CUdeviceptr ptr;
@@ -92,7 +92,7 @@ namespace gdrcopy {
             return ret;
         }
 
-        CUresult gpu_vmm_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_vmm_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops)
         {
             CUresult ret = CUDA_SUCCESS;
 
@@ -166,15 +166,6 @@ namespace gdrcopy {
                 goto out;
             }
 
-            if (set_sync_memops) {
-                unsigned int flag = 1;
-                ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
-                if (ret != CUDA_SUCCESS) {
-                    print_dbg("error in cuPointerSetAttribute\n");
-                    goto out;
-                }
-            }
-
             // cuMemAddressReserve always returns aligned ptr
             handle->ptr = ptr;
             handle->handle = mem_handle;
@@ -195,7 +186,7 @@ out:
             return ret;
         }
 
-        CUresult gpu_vmm_free(gpu_mem_handle_t *handle);
+        CUresult gpu_vmm_free(gpu_mem_handle_t *handle)
         {
             CUresult ret;
 
@@ -204,19 +195,19 @@ out:
 
             ret = cuMemUnmap(handle->ptr, handle->allocated_size);
             if (ret != CUDA_SUCCESS) {
-                ptrint_dbg("error in cuMemUnmap\n");
+                print_dbg("error in cuMemUnmap\n");
                 return ret;
             }
 
             ret = cuMemRelease(handle->handle);
             if (ret != CUDA_SUCCESS) {
-                ptrint_dbg("error in cuMemRelease\n");
+                print_dbg("error in cuMemRelease\n");
                 return ret;
             }
 
             ret = cuMemAddressFree(handle->ptr, handle->allocated_size);
             if (ret != CUDA_SUCCESS) {
-                ptrint_dbg("error in cuMemAddressFree\n");
+                print_dbg("error in cuMemAddressFree\n");
                 return ret;
             }
 

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -113,11 +113,21 @@ START_TEST(__testname) {                                                \
 #define BEGIN_CHECK do
 #define END_CHECK while(0)
 
-
-
 namespace gdrcopy {
     namespace test {
-        extern std::map<CUdeviceptr, CUdeviceptr> _allocations;
+        typedef struct gpuMemHandle 
+        {
+            CUdeviceptr ptr; // aligned ptr if requested; otherwise, the same as unaligned_ptr.
+            union {
+                CUdeviceptr unaligned_ptr; // for tracking original ptr; may be unaligned.
+                CUmemGenericAllocationHandle handle;
+            }
+            size_t size;
+            size_t allocated_size;
+        } gpu_mem_handle_t;
+
+        typedef CUresult gpu_memalloc_fn_t(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        typedef CUresult gpu_memfree_fn_t(gpu_mem_handle_t *handle);
 
         static inline gdr_t gdr_open_safe()
         {
@@ -129,62 +139,16 @@ namespace gdrcopy {
             return g;
         }
 
-        static inline CUresult gpuMemAlloc(CUdeviceptr *pptr, size_t psize, bool align_to_gpu_page = true, bool set_sync_memops = true)
-        {
-            CUresult ret = CUDA_SUCCESS;
-            CUdeviceptr ptr;
-            size_t size;
-
-            if (align_to_gpu_page)
-                size = psize + GPU_PAGE_SIZE - 1;
-            else
-                size = psize;
-
-            ret = cuMemAlloc(&ptr, size);
-            if (ret != CUDA_SUCCESS)
-                return ret;
-
-            if (set_sync_memops) {
-                unsigned int flag = 1;
-                ret = cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
-                if (ret != CUDA_SUCCESS) {
-                    cuMemFree(ptr);
-                    return ret;
-                }
-            }
-
-            if (align_to_gpu_page)
-                *pptr = (ptr + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
-            else
-                *pptr = ptr;
-
-            // Record the actual pointer for doing gpuMemFree later.
-            _allocations[*pptr] = ptr;
-
-            return CUDA_SUCCESS;
-        }
-
-        static inline CUresult gpuMemFree(CUdeviceptr pptr)
-        {
-            CUresult ret = CUDA_SUCCESS;
-            CUdeviceptr ptr;
-
-            if (_allocations.count(pptr) > 0) {
-                ptr = _allocations[pptr];
-                ret = cuMemFree(ptr);
-                if (ret == CUDA_SUCCESS)
-                    _allocations.erase(ptr);
-                return ret;
-            }
-            else
-                return CUDA_ERROR_INVALID_VALUE;
-        }
-
         extern bool print_dbg_msg;
+        extern const char *testname;
 
         void print_dbg(const char* fmt, ...);
 
-        extern const char *testname;
+        CUresult gpu_mem_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_mem_free(gpu_mem_handle_t *handle);
+
+        CUresult gpu_vmm_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_vmm_free(gpu_mem_handle_t *handle);
 
         static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {
             return a.h == b.h;

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -126,7 +126,7 @@ namespace gdrcopy {
             size_t allocated_size;
         } gpu_mem_handle_t;
 
-        typedef CUresult (*gpu_memalloc_fn_t)(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        typedef CUresult (*gpu_memalloc_fn_t)(gpu_mem_handle_t *handle, const size_t size, bool aligned_mapping, bool set_sync_memops);
         typedef CUresult (*gpu_memfree_fn_t)(gpu_mem_handle_t *handle);
 
         static inline gdr_t gdr_open_safe()
@@ -144,10 +144,10 @@ namespace gdrcopy {
 
         void print_dbg(const char* fmt, ...);
 
-        CUresult gpu_mem_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_mem_alloc(gpu_mem_handle_t *handle, const size_t size, bool aligned_mapping, bool set_sync_memops);
         CUresult gpu_mem_free(gpu_mem_handle_t *handle);
 
-        CUresult gpu_vmm_alloc(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        CUresult gpu_vmm_alloc(gpu_mem_handle_t *handle, const size_t size, bool aligned_mapping, bool set_sync_memops);
         CUresult gpu_vmm_free(gpu_mem_handle_t *handle);
 
         static inline bool operator==(const gdr_mh_t &a, const gdr_mh_t &b) {

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -73,6 +73,7 @@ START_TEST(__testname) {                                                \
             print_dbg("&&&& FAILED %s\n", gdrcopy::test::testname);     \
             ck_abort();                                                 \
         }                                                               \
+        __child_exit_status = WEXITSTATUS(__child_exit_status);         \
         if (__child_exit_status == EXIT_SUCCESS)                        \
             print_dbg("&&&& PASSED %s\n", gdrcopy::test::testname);     \
         else if (__child_exit_status == EXIT_WAIVED)                    \

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -120,7 +120,10 @@ namespace gdrcopy {
             CUdeviceptr ptr; // aligned ptr if requested; otherwise, the same as unaligned_ptr.
             union {
                 CUdeviceptr unaligned_ptr; // for tracking original ptr; may be unaligned.
+                #if CUDA_VERSION >= 10020
+                // Virtual Memory Management is available from CUDA 10.2
                 CUmemGenericAllocationHandle handle;
+                #endif
             };
             size_t size;
             size_t allocated_size;

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -121,13 +121,13 @@ namespace gdrcopy {
             union {
                 CUdeviceptr unaligned_ptr; // for tracking original ptr; may be unaligned.
                 CUmemGenericAllocationHandle handle;
-            }
+            };
             size_t size;
             size_t allocated_size;
         } gpu_mem_handle_t;
 
-        typedef CUresult gpu_memalloc_fn_t(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
-        typedef CUresult gpu_memfree_fn_t(gpu_mem_handle_t *handle);
+        typedef CUresult (*gpu_memalloc_fn_t)(gpu_mem_handle_t *handle, const size_t size, bool align_to_gpu_page, bool set_sync_memops);
+        typedef CUresult (*gpu_memfree_fn_t)(gpu_mem_handle_t *handle);
 
         static inline gdr_t gdr_open_safe()
         {

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -1815,14 +1815,14 @@ int main(int argc, char *argv[])
 {
     int c;
 
-    while ((c = getopt(argc, argv, "h::v::")) != -1) {
+    while ((c = getopt(argc, argv, "vh")) != -1) {
         switch (c) {
             case 'v':
                 gdrcopy::test::print_dbg_msg = true;
                 break;
             case 'h':
                 cout << "Usage: " << argv[0] << " [-v] [-h]" << endl;
-                break;
+                return EXIT_SUCCESS;
             case '?':
                 if (isprint(optopt))
                     fprintf(stderr, "Unknown option `-%c'.\n", optopt);
@@ -1830,7 +1830,7 @@ int main(int argc, char *argv[])
                     fprintf(stderr,
                             "Unknown option character `\\x%x'.\n",
                             optopt);
-                return 1;
+                return EXIT_FAILURE;
             default:
                 abort();
         }

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -1847,37 +1847,45 @@ int main(int argc, char *argv[])
     int nf;
 
     suite_add_tcase(s, tc_basic);
+    suite_add_tcase(s, tc_data_validation);
+    suite_add_tcase(s, tc_invalidation);
+
     tcase_add_test(tc_basic, basic_cumemalloc);
-    tcase_add_test(tc_basic, basic_vmmalloc);
     tcase_add_test(tc_basic, basic_with_tokens);
     tcase_add_test(tc_basic, basic_unaligned_mapping);
     tcase_add_test(tc_basic, basic_child_thread_pins_buffer_cumemalloc);
+
+    tcase_add_test(tc_data_validation, data_validation_cumemalloc);
+
+    tcase_add_test(tc_invalidation, invalidation_access_after_gdr_close_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_access_after_free_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_two_mappings_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_fork_access_after_free_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_fork_after_gdr_map_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_fork_child_gdr_map_parent_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_fork_map_and_free_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_pin_buffer_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_map_cumemalloc);
+    tcase_add_test(tc_invalidation, invalidation_fork_child_gdr_pin_parent_with_tokens);
+
+
+    #if CUDA_VERSION >= 10020
+    // VMM is available since CUDA 10.2
+    tcase_add_test(tc_basic, basic_vmmalloc);
     tcase_add_test(tc_basic, basic_child_thread_pins_buffer_vmmalloc);
 
-    suite_add_tcase(s, tc_data_validation);
-    tcase_add_test(tc_data_validation, data_validation_cumemalloc);
     tcase_add_test(tc_data_validation, data_validation_vmmalloc);
 
-    suite_add_tcase(s, tc_invalidation);
-    tcase_add_test(tc_invalidation, invalidation_access_after_gdr_close_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_access_after_gdr_close_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_access_after_free_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_access_after_free_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_two_mappings_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_two_mappings_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_fork_access_after_free_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_fork_access_after_free_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_fork_after_gdr_map_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_fork_after_gdr_map_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_fork_child_gdr_map_parent_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_fork_child_gdr_map_parent_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_fork_map_and_free_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_fork_map_and_free_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_pin_buffer_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_pin_buffer_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_map_cumemalloc);
     tcase_add_test(tc_invalidation, invalidation_unix_sock_shared_fd_gdr_map_vmmalloc);
-    tcase_add_test(tc_invalidation, invalidation_fork_child_gdr_pin_parent_with_tokens);
+    #endif
 
     tcase_set_timeout(tc_basic, 60);
     tcase_set_timeout(tc_data_validation, 60);


### PR DESCRIPTION
Issue:
- See #177.

This PR:
- adds two gpu memory allocators: gpu_mem_alloc for cuMemAlloc, and gpu_vmm_alloc for cuMemCreate.
- modifies apiperf, copybw, copylat, and sanity to use gpu_mem_alloc and gpu_vmm_alloc.
- waives vmm-related unit tests in sanity if vmm is not supported (check both compile time and run time).
- fixes a bug that causes `waived` unit tests to be reported incorrectly.
- fixes a segfault bug in `print_histogram` when `den == 0`.
