### PR TITLE
Remove gdrdrv-dkms dependency enforcement from gdrcopy main package

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -11,6 +11,6 @@ Homepage: https://github.com/NVIDIA/gdrcopy
 Package: gdrcopy
 Architecture: any
 Multi-Arch: same
-Depends: gdrdrv-dkms (>= @FULL_VERSION@), ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: A low-latency GPU memory copy library 
  A low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology.

--- a/packages/debian/control
+++ b/packages/debian/control
@@ -11,6 +11,6 @@ Homepage: https://github.com/NVIDIA/gdrcopy
 Package: gdrcopy
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: libsubunit0, ${shlibs:Depends}, ${misc:Depends}
 Description: A low-latency GPU memory copy library 
  A low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology.

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -53,7 +53,7 @@ License:        MIT
 URL:            https://github.com/NVIDIA/gdrcopy
 Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  gcc kernel-headers check-devel
-Requires:       %{name}-%{kmod} check
+Requires:       check
 
 %package devel
 Summary: The development files


### PR DESCRIPTION
Problem: See issue #188.

This PR:
- removes gdrdrv-dkms dependency enforcement from gdrcopy.deb.
- removes gdrcopy-kmod dependency enforcement from gdrcopy.rpm.
- adds libsubunit0 dependency enforcement to gdrcopy.deb. `sanity` requires it but the dependency is not declared in the deb package. For rpm, this dependency is auto-discovered.

With this PR, now the package metadata looks like
```
$ dpkg-deb -I gdrcopy_2.2-1_amd64.deb 
 new Debian package, version 2.0.
 size 54016 bytes: control archive=900 bytes.
     388 bytes,    12 lines      control              
     494 bytes,     8 lines      md5sums              
      20 bytes,     1 lines      shlibs               
      74 bytes,     2 lines      triggers             
 Package: gdrcopy
 Version: 2.2-1
 Architecture: amd64
 Maintainer: Davide Rossetti <drossetti@nvidia.com>
 Installed-Size: 176
 Depends: libsubunit0, libc6 (>= 2.14)
 Section: libs
 Priority: optional
 Multi-Arch: same
 Homepage: https://github.com/NVIDIA/gdrcopy
 Description: A low-latency GPU memory copy library
  A low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology.
```

```
$ rpm -qp --requires gdrcopy-2.2-1.x86_64.rpm
check
libc.so.6()(64bit)
libc.so.6(GLIBC_2.11)(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libgdrapi.so.2()(64bit)
libm.so.6()(64bit)
libm.so.6(GLIBC_2.2.5)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.3.3)(64bit)
librt.so.1()(64bit)
librt.so.1(GLIBC_2.2.5)(64bit)
librt.so.1(GLIBC_2.3.3)(64bit)
libstdc++.so.6()(64bit)
libstdc++.so.6(GLIBCXX_3.4)(64bit)
libstdc++.so.6(GLIBCXX_3.4.11)(64bit)
libstdc++.so.6(GLIBCXX_3.4.9)(64bit)
libsubunit.so.0()(64bit)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)
```