### PR TITLE
Fixed errors in init.d/gdrcopy when running on SLES

### DIFF
--- a/packages/rhel/init.d/gdrcopy
+++ b/packages/rhel/init.d/gdrcopy
@@ -14,7 +14,19 @@
 ### END INIT INFO
 
 # Source function library.
-. /etc/rc.d/init.d/functions
+if [ -f "/etc/rc.d/init.d/functions" ]; then
+    . /etc/rc.d/init.d/functions
+else
+    # On SLES, the functions file does not exist.
+    # We fall back to use our definitions.
+    function success() {
+        return 0
+    }
+
+    function failure() {
+        return $?
+    }
+fi
 
 
 DRIVER=gdrdrv


### PR DESCRIPTION
Problem:
- See issue #215.
- `/etc/rc.d/init.d/functions` is not available on SLES.

This PR:
- adds check if `init.d/functions` is available.
- if it isn't, we define our own `success` and `failure` functions.

Presubmit testing:
- on SLES15.2.
