### PR TITLE
Changed the definitions of gdr_open and gdr_init_cpu_flags

### DIFF
--- a/include/gdrapi.h
+++ b/include/gdrapi.h
@@ -65,7 +65,7 @@ typedef struct gdr *gdr_t;
 
 // Initialize the library, e.g. by opening a connection to the kernel-mode
 // driver. Returns an handle to the library state object.
-gdr_t gdr_open();
+gdr_t gdr_open(void);
 
 // Destroy library state object, e.g. it closes the connection to kernel-mode
 // driver.

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -98,9 +98,9 @@ static gdr_mh_t from_memh(gdr_memh_t *memh) {
     return mh;
 }
 
-static void gdr_init_cpu_flags();
+static void gdr_init_cpu_flags(void);
 
-gdr_t gdr_open()
+gdr_t gdr_open(void)
 {
     gdr_t g = NULL;
     const char *gdrinode = "/dev/gdrdrv";
@@ -427,7 +427,7 @@ static int has_sse4_1 = 0;
 static int has_avx = 0;
 static int has_avx2 = 0;
 
-static void gdr_init_cpu_flags()
+static void gdr_init_cpu_flags(void)
 {
 #ifdef GDRAPI_X86
     unsigned int info_type = 0x00000001;


### PR DESCRIPTION
Issues:
- See #218.
- gdr_init_cpu_flags also has similar issue.

The PR:
- changes the definitions of `gdr_open()` to `gdr_open(void)`.
- changes the definitions of `gdr_init_cpu_flags()` to `gdr_init_cpu_flags(void)`.

Presubmit testing:
- on gc11.