### PR TITLE
Fix minor readability issue in gdr_open

### DIFF
--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -160,7 +160,7 @@ gdr_t gdr_open(void)
     g->page_shift = -1;
     while (ps_tmp > 0) {
         ++g->page_shift;
-        if (ps_tmp & 0x1 == 1)
+        if ((ps_tmp & 0x1) == 1)
             break;
         ps_tmp >>= 1;
     }


### PR DESCRIPTION
Helpfully hinted by Clang: & has lower precedence than ==; == will be evaluated first.

The result is the same: `(ps_tmp) & (0x1 == 1)` is `ps_tmp & 1` is `(ps_tmp & 0x1) == 1`, but the current form looks dangerously misleading.