### PR TITLE
remove build time dependency on CUDA runtime header

### DIFF
--- a/tests/apiperf.cpp
+++ b/tests/apiperf.cpp
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <iomanip>
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 using namespace std;
 

--- a/tests/copylat.cpp
+++ b/tests/copylat.cpp
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <iomanip>
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 using namespace std;
 

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -33,7 +33,6 @@
 #include <unistd.h>
 #include <iostream>
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 #include <check.h>
 #include <errno.h>
 #include <sys/queue.h>


### PR DESCRIPTION
cuda_runtime_api.h is included but not really used by test apps, so let us get rid of that inclusion