### PR TITLE
Makefile: remove `ldconfig -n`.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,6 @@ lib: $(LIB)
 $(LIBOBJS): CFLAGS+=-fPIC
 $(LIB): $(LIBOBJS)
 	$(CC) -shared -Wl,-soname,$(LIB_SONAME) -o $@ $^
-	ldconfig -n $(PWD)
 	ln -sf $(LIB_DYNAMIC) $(LIB_SONAME)
 	ln -sf $(LIB_SONAME) $(LIB_BASENAME)
 


### PR DESCRIPTION
`ldconfig` can't be assumed to be available.

```
ldconfig -n /tmp/spack-stage/spack-stage-gdrcopy-2.3-lxw353euu26enjkcctzbux6n6cj3wjgt/spack-src/src
make[1]: ldconfig: Command not found
make[1]: *** [Makefile:60: libgdrapi.so.2.3] Error 127
```

```
cat /etc/os-release 
NAME="SLES"
VERSION="15-SP2"
VERSION_ID="15.2"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP2"
```