### PR TITLE
Fix an error about allocation size calculation when doing alignment with cuMemAlloc

### DIFF
--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -50,7 +50,7 @@ namespace gdrcopy {
             size_t allocated_size;
 
             if (aligned_mapping)
-                allocated_size = PAGE_ROUND_UP(size, GPU_PAGE_SIZE);
+                allocated_size = size + GPU_PAGE_SIZE - 1;
             else
                 allocated_size = size;
 


### PR DESCRIPTION
Issue:
- `gpu_mem_alloc` in tests/common.cpp is incorrect. The `allocated_size` may be too small. For example, requesting `size=60000` with `aligned_mapping=true`, we get `allocated_size=65536`. If `cuMemAlloc` returns the ptr=0x1, the aligned_ptr will be rounded up to 0x10000. This leaves the size of only 1 byte -- not 60000 bytes as requested.
- This error is introduced in #214.

This PR:
- reverts the allocated_size calculation to `allocated_size = size + GPU_PAGE_SIZE - 1;`.