### PR TITLE
Mpsd/deb packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ packages/*.deb
 packages/*.debian.tar.xz
 packages/*.dsc
 packages/*.orig.tar.gz
+packages/*.changes
+packages/*.buildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@
 # Editor files
 *~
 *.swp
+
+# Debian packages
+packages/*.deb
+packages/*.debian.tar.xz
+packages/*.dsc
+packages/*.orig.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ clean:
 	$(MAKE) clean
 	cd src/gdrdrv && \
 	$(MAKE) clean
+	rm -f packages/*.deb
+	rm -f packages/*.debian.tar.xz
+	rm -f packages/*.dsc
+	rm -f packages/*.orig.tar.gz
+	rm -f packages/*.changes
+	rm -f packages/*.buildinfo
 
 .PHONY: driver clean all lib exes lib_install drv_install exes_install install
 

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -23,6 +23,7 @@
 # Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
 # See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 DEBIAN_VERSION=1
+DEBIAN_RELEASE=unstable
 
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."
@@ -134,6 +135,7 @@ ex cp README.md ${tmpdir}/gdrcopy/debian-tests/README.source
 ex cd ${tmpdir}/gdrcopy
 ex find . -type f -exec sed -i "s/@FULL_VERSION@/${FULL_VERSION}/g" {} +
 ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
+ex find . -type f -exec sed -i "s/@DEBIAN_RELEASE@/${DEBIAN_RELEASE}/g" {} +
 
 ex rm -f ${tmpdir}/libgdrapi_${VERSION}.orig.tar.gz
 ex rm -f ${tmpdir}/gdrcopy-tests_${VERSION}.orig.tar.gz
@@ -195,6 +197,7 @@ if [[ ${build_driver_package} == 1 ]]; then
     ex find . -type f -exec sed -i "s/@FULL_VERSION@/${FULL_VERSION}/g" {} +
     ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
     ex find . -type f -exec sed -i "s/@MODULE_LOCATION@/${MODULE_SUBDIR//\//\\/}/g" {} +
+    ex find . -type f -exec sed -i "s/@DEBIAN_RELEASE@/${DEBIAN_RELEASE}/g" {} +
 
     ex cd ${tmpdir}
     ex tar czvf gdrdrv-dkms_${VERSION}.orig.tar.gz gdrdrv-dkms-${VERSION}
@@ -215,6 +218,7 @@ ex cd ${metadir}
 ex find . -type f -exec sed -i "s/@FULL_VERSION@/${FULL_VERSION}/g" {} +
 ex find . -type f -exec sed -i "s/@VERSION@/${VERSION}/g" {} +
 ex find . -type f -exec sed -i "s/@MODULE_LOCATION@/${MODULE_SUBDIR//\//\\/}/g" {} +
+ex find . -type f -exec sed -i "s/@DEBIAN_RELEASE@/${DEBIAN_RELEASE}/g" {} +
 ex cd ${tmpdir}
 ex tar czvf gdrcopy_${VERSION}.orig.tar.gz gdrcopy-${VERSION}
 cd ${metadir}

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -35,7 +35,7 @@ build_test_package=1
 build_driver_package=1
 keep_deb_filenames=0
 
-git_commit_date=$(git show -s --format='%cd' --date='format:%Y%m%d%H%M%S' 2>/dev/null)
+git_commit_date=""
 
 ex()
 {
@@ -52,13 +52,14 @@ ex()
 
 function show_help
 {
-    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] [-O] [-R <release>]  [-h]"
+    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] [-O] [-g] [-R <release>]  [-h]"
     echo ""
     echo "  CUDA=<path>     Set your installed CUDA path (ex. /usr/local/cuda)."
     echo "  -d              Don't check build dependencies. Use my environment variables such as C_INCLUDE_PATH instead."
     echo "  -t              Skip building gdrcopy-tests package."
     echo "  -k              Skip building gdrdrv-dkms package."
     echo "  -O              Keep original package filenames."
+    echo "  -g              Include date of latest git commit in version number."
     echo "  -R <release>    Set debian release in changelog, dsc and changes files. (Default: unstable)"
     echo "  -h              Show this help text."
     echo ""
@@ -66,7 +67,7 @@ function show_help
 
 OPTIND=1	# Reset in case getopts has been used previously in the shell.
 
-while getopts "hdtkOR:" opt; do
+while getopts "hdtkOgR:" opt; do
     case "${opt}" in
     h)
         show_help
@@ -79,6 +80,8 @@ while getopts "hdtkOR:" opt; do
     k)  build_driver_package=0
         ;;
     O)  keep_deb_filenames=1
+        ;;
+    g)  git_commit_date=$(git show -s --format='%cd' --date='format:%Y%m%d%H%M%S' 2>/dev/null)
         ;;
     R)  DEBIAN_RELEASE=$OPTARG
         ;;

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -244,7 +244,7 @@ ex cd ${CWD}
 
 for item in `ls ${tmpdir}/*.deb`; do
     item_name=`basename $item`
-    if [ $keep_deb_filenames != 0 ] ; then
+    if [ $keep_deb_filenames = 0 ] ; then
         item_name=`echo $item_name | sed -e "s/\.deb//g"`
         if echo "$item_name" | grep -q "tests"; then
             item_name="${item_name}${release}+cuda${CUDA_MAJOR}.${CUDA_MINOR}.deb"

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -32,6 +32,7 @@ CWD=$(pwd)
 skip_dep_check=0
 build_test_package=1
 build_driver_package=1
+keep_deb_filenames=0
 
 ex()
 {
@@ -48,12 +49,13 @@ ex()
 
 function show_help
 {
-    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] [-h]"
+    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] -O [-h]"
     echo ""
     echo "  CUDA=<path>     Set your installed CUDA path (ex. /usr/local/cuda)."
     echo "  -d              Don't check build dependencies. Use my environment variables such as C_INCLUDE_PATH instead."
     echo "  -t              Skip building gdrcopy-tests package."
     echo "  -k              Skip building gdrdrv-dkms package."
+    echo "  -O              Keep original package filenames."
     echo "  -h              Show this help text."
     echo ""
 }
@@ -71,6 +73,8 @@ while getopts "hdtk" opt; do
     t)  build_test_package=0
         ;;
     k)  build_driver_package=0
+        ;;
+    O)  keep_deb_filenames=1
         ;;
     esac
 done
@@ -228,11 +232,13 @@ ex cd ${CWD}
 
 for item in `ls ${tmpdir}/*.deb`; do
     item_name=`basename $item`
-    item_name=`echo $item_name | sed -e "s/\.deb//g"`
-    if echo "$item_name" | grep -q "tests"; then
-        item_name="${item_name}${release}+cuda${CUDA_MAJOR}.${CUDA_MINOR}.deb"
-    else
-        item_name="${item_name}${release}.deb"
+    if [ $keep_deb_filenames != 0 ] ; then
+        item_name=`echo $item_name | sed -e "s/\.deb//g"`
+        if echo "$item_name" | grep -q "tests"; then
+            item_name="${item_name}${release}+cuda${CUDA_MAJOR}.${CUDA_MINOR}.deb"
+        else
+            item_name="${item_name}${release}.deb"
+        fi
     fi
     ex cp $item ./${item_name}
 done

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -34,6 +34,8 @@ build_test_package=1
 build_driver_package=1
 keep_deb_filenames=0
 
+git_commit_date=$(git show -s --format='%cd' --date='format:%Y%m%d%H%M%S' 2>/dev/null)
+
 ex()
 {
     local rc
@@ -100,7 +102,7 @@ MODULE_SUBDIR=$(awk '/MODULE_SUBDIR \?=/ { print $3 }' ${TOP_DIR_PATH}/src/gdrdr
 
 MAJOR_VERSION=$(awk '/#define GDR_API_MAJOR_VERSION/ { print $3 }' ${TOP_DIR_PATH}/include/gdrapi.h | tr -d '\n')
 MINOR_VERSION=$(awk '/#define GDR_API_MINOR_VERSION/ { print $3 }' ${TOP_DIR_PATH}/include/gdrapi.h | tr -d '\n')
-VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
+VERSION="${MAJOR_VERSION}.${MINOR_VERSION}${git_commit_date:++git$git_commit_date}"
 if [ "X$VERSION" == "X" ]; then
     echo "Failed to get version numbers!" >&2
     exit 1

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -238,6 +238,8 @@ for item in `ls ${tmpdir}/*.deb`; do
 done
 ex cp ${tmpdir}/*.tar.* .
 ex cp ${tmpdir}/*.dsc .
+ex cp ${tmpdir}/*.changes .
+ex cp ${tmpdir}/*.buildinfo .
 
 echo
 echo "Cleaning up ..."

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -52,20 +52,21 @@ ex()
 
 function show_help
 {
-    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] -O [-h]"
+    echo "Usage: [CUDA=<path>] $0 [-d] [-t] [-k] [-O] [-R <release>]  [-h]"
     echo ""
     echo "  CUDA=<path>     Set your installed CUDA path (ex. /usr/local/cuda)."
     echo "  -d              Don't check build dependencies. Use my environment variables such as C_INCLUDE_PATH instead."
     echo "  -t              Skip building gdrcopy-tests package."
     echo "  -k              Skip building gdrdrv-dkms package."
     echo "  -O              Keep original package filenames."
+    echo "  -R <release>    Set debian release in changelog, dsc and changes files. (Default: unstable)"
     echo "  -h              Show this help text."
     echo ""
 }
 
 OPTIND=1	# Reset in case getopts has been used previously in the shell.
 
-while getopts "hdtk" opt; do
+while getopts "hdtkOR:" opt; do
     case "${opt}" in
     h)
         show_help
@@ -78,6 +79,8 @@ while getopts "hdtk" opt; do
     k)  build_driver_package=0
         ;;
     O)  keep_deb_filenames=1
+        ;;
+    R)  DEBIAN_RELEASE=$OPTARG
         ;;
     esac
 done

--- a/packages/debian-lib/changelog
+++ b/packages/debian-lib/changelog
@@ -1,4 +1,4 @@
-libgdrapi (@FULL_VERSION@) stable; urgency=low
+libgdrapi (@FULL_VERSION@) @DEBIAN_RELEASE@; urgency=low
 
   * Initial version of libgdrapi package -- was a part of gdrcopy package.
 

--- a/packages/debian-meta/changelog
+++ b/packages/debian-meta/changelog
@@ -1,4 +1,4 @@
-gdrcopy (@FULL_VERSION@) stable; urgency=low
+gdrcopy (@FULL_VERSION@) @DEBIAN_RELEASE@; urgency=low
 
   * Convert to meta package.
   * Declare dependency with gdrdrv-dkms, libgdrapi, and gdrcopy-tests.

--- a/packages/debian-tests/changelog
+++ b/packages/debian-tests/changelog
@@ -1,4 +1,4 @@
-gdrcopy-tests (@FULL_VERSION@) stable; urgency=low
+gdrcopy-tests (@FULL_VERSION@) @DEBIAN_RELEASE@; urgency=low
 
   * Initial version of gdrcopy-tests package -- was a part of gdrcopy package.
   * Add apiperf test.

--- a/packages/dkms/debian/changelog
+++ b/packages/dkms/debian/changelog
@@ -1,4 +1,4 @@
-gdrdrv-dkms (@FULL_VERSION@) unstable; urgency=low
+gdrdrv-dkms (@FULL_VERSION@) @DEBIAN_RELEASE@; urgency=low
 
   * Change the package maintainer to GPUDirect Team.
   * Add Davide Rossetti and Pak Makthub as Uploaders.

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ lib: $(LIB)
 $(LIBOBJS): CFLAGS+=-fPIC
 $(LIB): $(LIBOBJS)
 	$(CC) -shared -Wl,-soname,$(LIB_SONAME) -o $@ $^
-	ldconfig -n $(PWD)
+	# ldconfig -n $(PWD)
 	ln -sf $(LIB_DYNAMIC) $(LIB_SONAME)
 	ln -sf $(LIB_SONAME) $(LIB_BASENAME)
 


### PR DESCRIPTION
Several improvements for debian packages:
- make clean removes the generated package files, and they are git-ignored
- buildinfo and changes files are also copied back, important for uploading to local apt repo:
  - you can run debsign -k <key-id> *.changes
  - and then dput <my-repo> *.changes
- add option -O (to keep the original package name, to be consistent with the changes file)
- add option -R (sets the release name in changelog and changes file)
- add option -g (appends the date of the latest git commit to the version number)