### PR TITLE
Add "gdrcopy_" as prefix to the names of the test applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ A simple by-product of it is a copy library with the following characteristics:
   PCIE
 
 The library comes with a few tests like:
-- sanity, which contains unit tests for the library and the driver.
-- copybw, a minimal application which calculates the R/W bandwidth for a specific buffer size.
-- copylat, a benchmark application which calculates the R/W copy latency for a range of buffer sizes.
+- gdrcopy_sanity, which contains unit tests for the library and the driver.
+- gdrcopy_copybw, a minimal application which calculates the R/W bandwidth for a specific buffer size.
+- gdrcopy_copylat, a benchmark application which calculates the R/W copy latency for a range of buffer sizes.
+- gdrcopy_apiperf, an application for benchmarking the latency of each GDRCopy API call.
 
 ## Requirements
 
@@ -48,7 +49,7 @@ please refer to the official GPUDirect RDMA [design
 document](http://docs.nvidia.com/cuda/gpudirect-rdma).
 
 The device driver requires GPU display driver >= 418.40 on ppc64le and >= 331.14 on other platforms. The library and tests
-require CUDA >= 6.0. Additionally, the _sanity_ test requires check >= 0.9.8 and
+require CUDA >= 6.0. Additionally, the `gdrcopy_sanity` test requires check >= 0.9.8 and
 subunit.
 
 DKMS is a prerequisite for installing GDRCopy kernel module package. On RHEL,
@@ -133,12 +134,12 @@ $ PKG_CONFIG_PATH=/check_install_path/lib/pkgconfig/ make <...>
 
 Execute provided tests:
 ```shell
-$ sanity 
+$ gdrcopy_sanity
 Running suite(s): Sanity
 100%: Checks: 27, Failures: 0, Errors: 0
 
 
-$ copybw
+$ gdrcopy_copybw
 GPU id:0; name: Tesla V100-SXM2-32GB; Bus id: 0000:06:00
 GPU id:1; name: Tesla V100-SXM2-32GB; Bus id: 0000:07:00
 GPU id:2; name: Tesla V100-SXM2-32GB; Bus id: 0000:0a:00
@@ -169,7 +170,7 @@ unpinning buffer
 closing gdrdrv
 
 
-$ copylat
+$ gdrcopy_copylat
 GPU id:0; name: Tesla V100-SXM2-32GB; Bus id: 0000:06:00
 GPU id:1; name: Tesla V100-SXM2-32GB; Bus id: 0000:07:00
 GPU id:2; name: Tesla V100-SXM2-32GB; Bus id: 0000:0a:00
@@ -254,7 +255,7 @@ unpinning buffer
 closing gdrdrv
 
 
-$ apiperf -s 8
+$ gdrcopy_apiperf -s 8
 GPU id:0; name: Tesla V100-SXM2-32GB; Bus id: 0000:06:00
 GPU id:1; name: Tesla V100-SXM2-32GB; Bus id: 0000:07:00
 GPU id:2; name: Tesla V100-SXM2-32GB; Bus id: 0000:0a:00
@@ -296,7 +297,7 @@ CPU socket 0. By explicitly playing with the OS process and memory
 affinity, it is possible to run the test onto the optimal processor:
 
 ```shell
-$ numactl -N 0 -l copybw -d 0 -s $((64 * 1024)) -o $((0 * 1024)) -c $((64 * 1024))
+$ numactl -N 0 -l gdrcopy_copybw -d 0 -s $((64 * 1024)) -o $((0 * 1024)) -c $((64 * 1024))
 GPU id:0; name: Tesla V100-SXM2-32GB; Bus id: 0000:06:00
 GPU id:1; name: Tesla V100-SXM2-32GB; Bus id: 0000:07:00
 GPU id:2; name: Tesla V100-SXM2-32GB; Bus id: 0000:0a:00
@@ -329,7 +330,7 @@ closing gdrdrv
 
 or on the other socket:
 ```shell
-$ numactl -N 1 -l copybw -d 0 -s $((64 * 1024)) -o $((0 * 1024)) -c $((64 * 1024))
+$ numactl -N 1 -l gdrcopy_copybw -d 0 -s $((64 * 1024)) -o $((0 * 1024)) -c $((64 * 1024))
 GPU id:0; name: Tesla V100-SXM2-32GB; Bus id: 0000:06:00
 GPU id:1; name: Tesla V100-SXM2-32GB; Bus id: 0000:07:00
 GPU id:2; name: Tesla V100-SXM2-32GB; Bus id: 0000:0a:00

--- a/packages/debian-tests/rules
+++ b/packages/debian-tests/rules
@@ -24,7 +24,7 @@ override_dh_auto_build:
 	dh_auto_build -- CUDA=$(CUDA) lib exes
 
 override_dh_shlibdeps:
-	dh_shlibdeps -Xapiperf -Xcopybw -Xcopylat -Xsanity
+	dh_shlibdeps -Xgdrcopy_apiperf -Xgdrcopy_copybw -Xgdrcopy_copylat -Xgdrcopy_sanity
 
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$(CURDIR)/debian/gdrcopy-tests prefix=/usr exes_install

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -260,6 +260,10 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 %{_prefix}/bin/copybw
 %{_prefix}/bin/copylat
 %{_prefix}/bin/sanity
+%{_prefix}/bin/gdrcopy_apiperf
+%{_prefix}/bin/gdrcopy_copybw
+%{_prefix}/bin/gdrcopy_copylat
+%{_prefix}/bin/gdrcopy_sanity
 %{_libdir}/libgdrapi.so.?.?
 %{_libdir}/libgdrapi.so.?
 %{_libdir}/libgdrapi.so

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,9 +55,9 @@ install: exes
 	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_apiperf -t $(DESTBIN) && \
 	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_sanity -t $(DESTBIN)
 	cd $(DESTBIN) && \
-	ln -s gdrcopy_copybw copybw && \
-	ln -s gdrcopy_copylat copylat && \
-	ln -s gdrcopy_apiperf apiperf && \
-	ln -s gdrcopy_sanity sanity
+	ln -sf gdrcopy_copybw copybw && \
+	ln -sf gdrcopy_copylat copylat && \
+	ln -sf gdrcopy_apiperf apiperf && \
+	ln -sf gdrcopy_sanity sanity
 
 .PHONY: clean all exes install

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ CXXFLAGS += $(COMMONCFLAGS)
 LIBS     := -lcuda -lpthread -ldl -lgdrapi
 
 SRCS := copybw.cpp sanity.cpp copylat.cpp apiperf.cpp
-EXES := $(SRCS:.cpp=)
+EXES := $(patsubst %.cpp,gdrcopy_%,$(SRCS))
 
 all: exes
 
@@ -32,16 +32,16 @@ sanity.o: sanity.cpp $(GDRAPI_INC)/gdrapi.h $(GDRAPI_SRC)/gdrapi_internal.h comm
 copylat.o: copylat.cpp $(GDRAPI_INC)/gdrapi.h common.hpp
 apiperf.o: apiperf.cpp $(GDRAPI_INC)/gdrapi.h common.hpp
 
-copybw: copybw.o common.o
+gdrcopy_copybw: copybw.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) -lrt
 
-sanity: sanity.o common.o
+gdrcopy_sanity: sanity.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) $(CHECK_LIBS)
 
-copylat: copylat.o common.o
+gdrcopy_copylat: copylat.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) -lrt
 
-apiperf: apiperf.o common.o
+gdrcopy_apiperf: apiperf.o common.o
 	$(LINK.cc)  -o $@ $^ $(LIBS) -lrt
 
 clean:
@@ -50,9 +50,14 @@ clean:
 install: exes
 	@ echo "installing exes in $(DESTBIN)..." && \
 	mkdir -p $(DESTBIN) && \
-	install -D -v -m u=rwx,g=rx,o=rx copybw -t $(DESTBIN) && \
-	install -D -v -m u=rwx,g=rx,o=rx copylat -t $(DESTBIN) && \
-	install -D -v -m u=rwx,g=rx,o=rx apiperf -t $(DESTBIN) && \
-	install -D -v -m u=rwx,g=rx,o=rx sanity -t $(DESTBIN)
+	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_copybw -t $(DESTBIN) && \
+	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_copylat -t $(DESTBIN) && \
+	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_apiperf -t $(DESTBIN) && \
+	install -D -v -m u=rwx,g=rx,o=rx gdrcopy_sanity -t $(DESTBIN)
+	cd $(DESTBIN) && \
+	ln -s gdrcopy_copybw copybw && \
+	ln -s gdrcopy_copylat copylat && \
+	ln -s gdrcopy_apiperf apiperf && \
+	ln -s gdrcopy_sanity sanity
 
 .PHONY: clean all exes install


### PR DESCRIPTION
This PR:
- adds "gdrcopy_" prefix to the test applications' names.
- symlinks the original names to gdrcopy_*.
- modified the packaging scripts to use the new names.

Fixes #241.

Presubmit testing:
- `make install`.
- created and verified deb and rpm packages.