### PR TITLE
Allow tests to build against libcuda.so stub

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ CHECK_LIBS := $(shell pkg-config --libs check)
 GDRAPI_INC := ../include
 GDRAPI_SRC := ../src
 
-CUDA_LIB := -L $(CUDA)/lib64 -L $(CUDA)/lib -L /usr/lib64/nvidia -L /usr/lib/nvidia
+CUDA_LIB := -L $(CUDA)/lib64 -L $(CUDA)/lib -L /usr/lib64/nvidia -L /usr/lib/nvidia -L $(CUDA)/lib64/stubs
 CUDA_INC += -I $(CUDA)/include
 
 CPPFLAGS := $(CUDA_INC) -I $(GDRAPI_INC) -I $(GDRAPI_SRC) -I $(CUDA)/include $(CHECK_INC)


### PR DESCRIPTION
With this change, you can run build-deb-packages.sh with only the following packages installed (so, it's easily containerized):
* cuda-cudart-dev-12-1
* cuda-driver-dev-12-1
* cuda-nvcc-12-1

Before this change, you need to mount the libcuda from the host driver into the container (e.g. using NVIDIA_DRIVER_CAPABILITIES).