### PR TITLE
Fixed the dependency declaration in debian-meta/control

### DIFF
--- a/packages/debian-meta/control
+++ b/packages/debian-meta/control
@@ -10,7 +10,7 @@ Homepage: https://github.com/NVIDIA/gdrcopy
 Package: gdrcopy
 Architecture: any
 Multi-Arch: same
-Depends: gdrdrv-dkms (= @FULL_VERSION@), libgdrapi (= @FULL_VERSION@), gdrcopy-tests (= @FULL_VERSION@)
+Depends: gdrdrv-dkms (= @VERSION@), libgdrapi (= @VERSION@), gdrcopy-tests (= @VERSION@)
 Maintainer: GPUDirect Team <gpudirect@nvidia.com>
 Uploaders: Davide Rossetti <drossetti@nvidia.com>, Pak Markthub <pmarkthub@nvidia.com>
 Description: GDRCopy meta-package


### PR DESCRIPTION
Problem:
- See #262.

This PR:
- changes the Depends field of debian-meta to `@VERSION@`.

Presubmit Testing:
- on Ubuntu 20.04.