### PR TITLE
Add Support for SLE and openSUSE Leap

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The device driver requires GPU display driver >= 418.40 on ppc64le and >= 331.14
 require CUDA >= 6.0. Additionally, the _sanity_ test requires check >= 0.9.8 and
 subunit.
 
-DKMS is a prerequisite for installing GDRCopy kernel module package. On RHEL,
+DKMS is a prerequisite for installing GDRCopy kernel module package. On RHEL
+or SLE,
 however, users have an option to build kmod and install it instead of the DKMS
 package. See [Build and installation](#build-and-installation) section for more details.
 
@@ -62,6 +63,10 @@ $ sudo yum install dkms check check-devel subunit subunit-devel
 
 # On Debian
 $ sudo apt install check libsubunit0 libsubunit-dev
+
+# On SLE / Leap
+# On SLE dkms can be installed from PackageHub.
+$ sudo zypper install dkms check-devel rpmbuild
 ```
 
 CUDA and GPU display driver must be installed before building and/or installing GDRCopy.
@@ -72,9 +77,11 @@ of the driver (or CUDA) installation with  *runfile*. If you install the driver
 via package management, we suggest
 - On RHEL, `sudo dnf module install nvidia-driver:latest-dkms`.
 - On Debian, `sudo apt install nvidia-dkms-<your-nvidia-driver-version>`.
+- On SLE, `sudo zypper install nvidia-gfx<your-nvidia-driver-version>-kmp`.
 
 The supported architectures are Linux x86_64, ppc64le, and arm64. The supported
-platforms are RHEL7, RHEL8, Ubuntu16_04, Ubuntu18_04, and Ubuntu20_04.
+platforms are RHEL7, RHEL8, Ubuntu16_04, Ubuntu18_04, Ubuntu20_04,
+SLE-15 (any SP) and Leap 15.x.
 
 Root privileges are necessary to load/install the kernel-mode device
 driver.
@@ -87,8 +94,13 @@ We provide three ways for building and installing GDRCopy.
 ### rpm package
 
 ```shell
+# For RHEL:
 $ sudo yum groupinstall 'Development Tools'
 $ sudo yum install dkms rpm-build make check check-devel subunit subunit-devel
+
+# For SLE:
+$ sudo zypper in dkms rpmbuild check-devel
+
 $ cd packages
 $ CUDA=<cuda-install-top-dir> ./build-rpm-packages.sh
 $ sudo rpm -Uvh gdrcopy-kmod-<version>dkms.noarch.<platform>.rpm

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -101,7 +101,7 @@ FULL_VERSION="${VERSION}"
 
 if [[ ${generate_kmod} == 1 ]]; then
     if [ -z "${NVIDIA_SRC_DIR}" ]; then
-        NVIDIA_SRC_DIR=$(find /usr/src/nvidia-* -name "nv-p2p.h" -print -quit)
+	NVIDIA_SRC_DIR=$(find /usr/src/kernel-modules/nvidia-* /usr/src/nvidia-* -name "nv-p2p.h" -print -quit 2>/dev/null)
         if [ ${#NVIDIA_SRC_DIR} -gt 0 ]; then
             NVIDIA_SRC_DIR=$(dirname ${NVIDIA_SRC_DIR})
         fi

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -160,6 +160,8 @@ if [ -f "/etc/redhat-release" ]; then
     release_version=".el$(cat /etc/redhat-release | grep -o -E '[0-9]+' | head -1)"
 elif [ -f "/etc/centos-release" ]; then
     release_version=".el$(cat /etc/centos-release | grep -o -E '[0-9]+' | head -1)"
+elif [ -f "/etc/os-release" ]; then
+    release_version=$(source /etc/os-release && echo ".$ID-$VERSION_ID")
 else
     release_version="unknown_distro"
 fi

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -168,12 +168,13 @@ fi
 echo $srpm $rpms
 ex cd ${CWD}
 for item in `ls $tmpdir/topdir/SRPMS/*.rpm $tmpdir/topdir/RPMS/*/*.rpm`; do
-    item_name=`basename $item`
-    item_name=`echo $item_name | sed -e "s/\.rpm//g"`
+    item_name=`basename $item .rpm`
+    arch=$(sed -ne 's/.*\(\.[^\.]\+\)$/\1/p' <<< $item_name)
+    item_name=`basename $item_name $arch`
     if [ "$item_name" == "gdrcopy-${FULL_VERSION}-${RPM_VERSION}.`uname -m`" ]; then
-        item_name="${item_name}${release_version}+cuda${CUDA_MAJOR}.${CUDA_MINOR}.rpm"
+        item_name="${item_name}${release_version}+cuda${CUDA_MAJOR}.${CUDA_MINOR}.${arch}.rpm"
     else
-        item_name="${item_name}${release_version}.rpm"
+        item_name="${item_name}${release_version}${arch}.rpm"
     fi
     ex cp $item ./${item_name}
 done

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ lib: $(LIB)
 $(LIBOBJS): CFLAGS+=-fPIC
 $(LIB): $(LIBOBJS)
 	$(CC) -shared -Wl,-soname,$(LIB_SONAME) -o $@ $^
-	ldconfig -n $(PWD)
+	PATH=/sbin:/usr/sbin:$$PATH; ldconfig -n $(PWD)
 	ln -sf $(LIB_DYNAMIC) $(LIB_SONAME)
 	ln -sf $(LIB_SONAME) $(LIB_BASENAME)
 

--- a/src/gdrdrv/Makefile
+++ b/src/gdrdrv/Makefile
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-NVIDIA_SRC_DIR ?= $(shell find /usr/src/nvidia-* -name "nv-p2p.h"|head -1|xargs dirname || echo "NVIDIA_DRIVER_MISSING")
+NVIDIA_SRC_DIR ?= $(shell { find /usr/src/kernel-modules/nvidia-* /usr/src/nvidia-* -name "nv-p2p.h" -print -quit | xargs dirname || echo "NVIDIA_DRIVER_MISSING"; } 2>/dev/null)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/src/gdrdrv/Makefile
+++ b/src/gdrdrv/Makefile
@@ -58,7 +58,7 @@ help:
 	$(MAKE) -C $(KDIR) M=$$PWD help
 
 clean:
-	rm -rf *.o .*.o.d *.ko* *.mod.* .*.cmd Module.symvers modules.order .tmp_versions/ *~ core .depend TAGS .cache.mk 
+	rm -rf *.o .*.o.d *.ko* *.mod.* .*.cmd Module.symvers modules.order .tmp_versions/ *~ core .depend TAGS .cache.mk  *.mod
 
 TAGS:
 	find $(KERNELDIR) -follow -name \*.h -o -name \*.c  |xargs etags


### PR DESCRIPTION
This PR:
-  Adds support for openSUSE/SUSE distributions:
   - Fixes search path to NVIDA kernel driver bits.
   - Correctly sets release_version for openSUSE/SUSE in RPM spec file,
   - Creates `modprobe` configuration to set up device,
   - Adds instructions to README how to build for openSUSE/SUSE.
- Makes sure, architecture is correctly appended as as last element in rpm package names.
- Makes sure, `ldconfig` is found even when building as user.