### PR TITLE
Add include/gdrconfig.h to gdrcopy.spec

### DIFF
--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -272,6 +272,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 %files devel
 %{_prefix}/include/gdrapi.h
+%{_prefix}/include/gdrconfig.h
 %doc README.md
 
 


### PR DESCRIPTION
Issue:
```
hecking for unpackaged file(s): /usr/lib/rpm/check-files /tmp/gdr.Dbd1pX/topdir/BUILDROOT/gdrcopy-2.3-1.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/include/gdrconfig.h


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/include/gdrconfig.h
```

This PR:
- adds `include/gdrconfig.h` to `gdrcopy.spec`.