### PR TITLE
Remove check header dependency + include string

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -27,7 +27,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <cuda.h>
-#include <check.h>
+#include <string.h>
 #include <map>
 #include <gdrapi.h>
 #include <gdrconfig.h>


### PR DESCRIPTION
If I understand correctly check lib dependency was removed several month ago, but common.hpp file still contains header inclusion. When I removed this header, I got the following errors on Ubuntu 20.04:

![image](https://github.com/NVIDIA/gdrcopy/assets/22097249/e1a9d72f-b7e2-4673-be20-e6f16cc9d1b6)

So I decided to fix two problems by one patch.