### PR TITLE
Fix issue 283: NVIDIA_IS_OPENSOURCE is not set correctly with NVIDIA driver version 545

### DIFF
--- a/src/gdrdrv/Makefile
+++ b/src/gdrdrv/Makefile
@@ -19,7 +19,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 NVIDIA_SRC_DIR ?= $(shell { find /usr/src/kernel-modules/nvidia-* /usr/src/nvidia-* -name "nv-p2p.c" -print -quit | xargs dirname || echo "NVIDIA_DRIVER_MISSING"; } 2>/dev/null)
-NVIDIA_IS_OPENSOURCE ?= $(shell grep -s -q "MODULE_LICENSE(\"Dual MIT/GPL\")" $(NVIDIA_SRC_DIR)/nv-frontend.c $(NVIDIA_SRC_DIR)/nv.c && echo "y")
+NVIDIA_IS_OPENSOURCE ?= $(shell grep -r "MODULE_LICENSE" $(NVIDIA_SRC_DIR)/ | grep -s -q "GPL" && echo "y")
 
 ifneq ($(KERNELRELEASE),)
 

--- a/src/gdrdrv/Makefile
+++ b/src/gdrdrv/Makefile
@@ -19,7 +19,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 NVIDIA_SRC_DIR ?= $(shell { find /usr/src/kernel-modules/nvidia-* /usr/src/nvidia-* -name "nv-p2p.c" -print -quit | xargs dirname || echo "NVIDIA_DRIVER_MISSING"; } 2>/dev/null)
-NVIDIA_IS_OPENSOURCE ?= $(shell grep -q "MODULE_LICENSE(\"Dual MIT/GPL\")" $(NVIDIA_SRC_DIR)/nv-frontend.c && echo "y")
+NVIDIA_IS_OPENSOURCE ?= $(shell grep -s -q "MODULE_LICENSE(\"Dual MIT/GPL\")" $(NVIDIA_SRC_DIR)/nv-frontend.c $(NVIDIA_SRC_DIR)/nv.c && echo "y")
 
 ifneq ($(KERNELRELEASE),)
 


### PR DESCRIPTION
Issue:
- See #283.
- Starting from NVIDIA driver version 545, `MODULE_LICENSE` is moved to `nv.c`.

This PR:
- includes `$(NVIDIA_SRC)/nv.c` to the search path.

Presubmit Testing:
- With proprietary flavor and opensource flavor of version 545.
- With driver version 520 to check regression.