### PR TITLE
Fix issue 276: Waive some unit tests in gdrcopy_sanity when GPU compute mode is not default

### DIFF
--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -1441,7 +1441,7 @@ void invalidation_fork_map_and_free()
 
     int mydata = (rand() % 1000) + 1;
 
-    init_cuda(0);
+    init_cuda(0, true);
     filter_fn();
 
     CUdeviceptr d_A;
@@ -1563,7 +1563,7 @@ void invalidation_unix_sock_shared_fd_gdr_pin_buffer()
 
     print_dbg("%s: Start\n", myname);
 
-    init_cuda(0);
+    init_cuda(0, true);
     filter_fn();
 
     CUdeviceptr d_A;
@@ -1695,7 +1695,7 @@ void invalidation_unix_sock_shared_fd_gdr_map()
         write_fd = filedes_1[1];
     }
 
-    init_cuda(0);
+    init_cuda(0, true);
     filter_fn();
 
     CUdeviceptr d_A;

--- a/tests/sanity.cpp
+++ b/tests/sanity.cpp
@@ -60,12 +60,21 @@ void exception_signal_handle(int sig)
     print_dbg("Unexpectedly get exception signal");
 }
 
-void init_cuda(int dev_id)
+void init_cuda(int dev_id, bool waive_if_not_in_default_compute_mode = false)
 {
     CUdevice dev;
     CUcontext dev_ctx;
     ASSERTDRV(cuInit(0));
     ASSERTDRV(cuDeviceGet(&dev, dev_id));
+
+    if (waive_if_not_in_default_compute_mode) {
+        int mode;
+        ASSERTDRV(cuDeviceGetAttribute(&mode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE, dev));
+        if (mode != CU_COMPUTEMODE_DEFAULT) {
+            print_dbg("Waive this test because GPU is not in the default compute mode.\n");
+            exit(EXIT_WAIVED);
+        }
+    }
 
     ASSERTDRV(cuDevicePrimaryCtxRetain(&dev_ctx, dev));
     ASSERTDRV(cuCtxSetCurrent(dev_ctx));


### PR DESCRIPTION
Issue:
- See #276.
- We cannot run two CUDA processes on the same GPU when the GPU is set to exclusive compute mode.

This PR:
- waives those unit tests in `gdrcopy_sanity` that require running two CUDA processes.
- We don't loss coverage because users cannot share GDRCopy resources among processes when the GPU is in the exclusive compute mode anyway.

Presubmit Testing:
- On x86 with Ampere GPU. Tested on both default and exclusive compute modes.