### PR TITLE
Add a new API to get DMA map of memory

### DIFF
--- a/include/gdrapi.h
+++ b/include/gdrapi.h
@@ -79,6 +79,7 @@ typedef struct gdr_mh_s {
 // Create a peer-to-peer mapping of the device memory buffer, returning an opaque handle.
 // Note that at this point the mapping is still not accessible to user-space.
 int gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle);
+int gdr_p2p_dma_map_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle, uint64_t *paddr);
 
 // Destroys the peer-to-peer mapping and frees the handle.
 //

--- a/src/gdrapi_internal.h
+++ b/src/gdrapi_internal.h
@@ -54,6 +54,7 @@ extern "C" {
 
 typedef struct gdr_memh_t { 
     uint32_t handle;
+    uint64_t paddr;
     LIST_ENTRY(gdr_memh_t) entries;
     gdr_mapping_type_t mapping_type;
 } gdr_memh_t;

--- a/src/gdrdrv/gdrdrv.h
+++ b/src/gdrdrv/gdrdrv.h
@@ -65,6 +65,7 @@ struct GDRDRV_IOC_PIN_BUFFER_PARAMS
     __u64 p2p_token;
     __u32 va_space;
     // out
+    __u64 paddr;
     gdr_hnd_t handle;
 };
 
@@ -147,6 +148,8 @@ struct GDRDRV_IOC_GET_VERSION_PARAMS
     __u32 gdrdrv_version;
     __u32 minimum_gdr_api_version;
 };
+
+#define GDRDRV_IOC_P2P_DMA_MAP_BUFFER _IOWR(GDRDRV_IOCTL, 6, struct GDRDRV_IOC_PIN_BUFFER_PARAMS)
 
 #define GDRDRV_IOC_GET_VERSION _IOWR(GDRDRV_IOCTL, 255, struct GDRDRV_IOC_GET_VERSION_PARAMS *)
 


### PR DESCRIPTION
Add a new API to get the DMA memory or the Physical Address of the peer mapped memory.
This will allow NIC devices to use the physical addresses directly instead of using the CUDA provided Unified Memory Address.