### PR TITLE
Improve cuda gencode flags

### DIFF
--- a/scripts/get_cuda_gencode.sh
+++ b/scripts/get_cuda_gencode.sh
@@ -60,12 +60,14 @@ fi
 
 # Generate NVCC flags
 GENCODE_FLAGS=""
-for arch in $ARCH_LIST; do
-    GENCODE_FLAGS="$GENCODE_FLAGS -gencode arch=compute_$arch,code=compute_$arch"
-done
 
+# Generate SM-specific code for all architectures
 for arch in $ARCH_LIST; do
     GENCODE_FLAGS="$GENCODE_FLAGS -gencode arch=compute_$arch,code=sm_$arch"
 done
+
+# Generate PTX code only for the latest architecture
+LATEST_ARCH=$(echo "$ARCH_LIST" | tr ' ' '\n' | sort -n | tail -1)
+GENCODE_FLAGS="$GENCODE_FLAGS -gencode arch=compute_$LATEST_ARCH,code=compute_$LATEST_ARCH"
 
 echo "$GENCODE_FLAGS"

--- a/scripts/get_cuda_gencode.sh
+++ b/scripts/get_cuda_gencode.sh
@@ -66,16 +66,10 @@ else
         SM_LIST="$SM_LIST 90"
     fi
 
-    # Add Blackwell (10.0) if CUDA >= 12.6
+    # Add Blackwell (10.0, 10.1, 12.0) if CUDA >= 12.8
     if [ "$CUDA_VERSION_MAJOR" -ge 12 ] && [ "$CUDA_VERSION_MINOR" -ge 6 ]; then
-        COMPUTE_LIST="$COMPUTE_LIST 100"
-        SM_LIST="$SM_LIST 100"
-    fi
-
-    # Add Blackwell (12.0) if CUDA >= 12.8
-    if [ "$CUDA_VERSION_MAJOR" -ge 12 ] && [ "$CUDA_VERSION_MINOR" -ge 8 ]; then
-        COMPUTE_LIST="$COMPUTE_LIST 120"
-        SM_LIST="$SM_LIST 120"
+        COMPUTE_LIST="$COMPUTE_LIST 100 101 120"
+        SM_LIST="$SM_LIST 100 101 120"
     fi
 fi
 


### PR DESCRIPTION
## Context

- The current cuda SASS/PTX list is hardcoded manually based on a versioning heuristic that is error-prone. Case in point:
  - blackwell sm 10.1 is missing
  - blackwell sm 10.0 is supported after 12.8, not 12.6. 
   ```make
   ```
- full arch list are used for code (SASS) and compute (PTX). For PTX, only latest is needed.

## Changes

- Use sm list from `nvcc --list-gpu-code` directly when available
- Fix blackwell sm list and version compatibility
- Consolidate compute & sm list in a single variable
- Only build PTX for last supported arch

