### PR TITLE
feat: return physical address base of memory range

### DIFF
--- a/include/gdrapi.h
+++ b/include/gdrapi.h
@@ -131,6 +131,7 @@ typedef struct gdr_info_v2 {
     unsigned mapped:1;
     unsigned wc_mapping:1;
     gdr_mapping_type_t mapping_type;
+    uint64_t paddr;
 } gdr_info_v2_t;
 typedef gdr_info_v2_t gdr_info_t;
 int gdr_get_info_v2(gdr_t g, gdr_mh_t handle, gdr_info_v2_t *info);

--- a/src/gdrapi.c
+++ b/src/gdrapi.c
@@ -379,6 +379,7 @@ int gdr_get_info_v2(gdr_t g, gdr_mh_t handle, gdr_info_v2_t *info)
             info->mapped        = gdr_is_mapped(params.mapping_type);
             info->wc_mapping    = (params.mapping_type == GDR_MAPPING_TYPE_WC);
             info->mapping_type  = params.mapping_type;
+            info->paddr         = params.paddr;
         }
     }
     else
@@ -400,6 +401,7 @@ int gdr_get_info_v2(gdr_t g, gdr_mh_t handle, gdr_info_v2_t *info)
             info->mapped        = params.mapped;
             info->wc_mapping    = params.wc_mapping;
             info->mapping_type  = params.mapped ? (params.wc_mapping ? GDR_MAPPING_TYPE_WC : GDR_MAPPING_TYPE_CACHING) : GDR_MAPPING_TYPE_NONE;
+            info->paddr         = params.paddr;
         }
     }
 
@@ -1040,6 +1042,7 @@ typedef struct gdr_info_v1 {
     uint32_t cycles_per_ms;
     unsigned mapped:1;
     unsigned wc_mapping:1;
+    uint64_t paddr;
 } gdr_info_v1_t;
 
 int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_v1_t *info)
@@ -1064,6 +1067,7 @@ int gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_v1_t *info)
         info->cycles_per_ms = params.tsc_khz;
         info->mapped        = params.mapped;
         info->wc_mapping    = params.wc_mapping;
+        info->paddr         = params.paddr;
     }
 
 out:

--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -1145,6 +1145,7 @@ static int gdrdrv_get_info(gdr_info_t *info, void __user *_params)
     params.tsc_khz      = mr->tsc_khz;
     params.mapped       = gdr_mr_is_mapped(mr);
     params.wc_mapping   = (mr->cpu_mapping_type == GDR_MR_WC);
+    params.paddr        = mr->page_table->pages[0]->physical_address;
 
     gdr_put_mr_read(mr);
 
@@ -1183,6 +1184,7 @@ static int gdrdrv_get_info_v2(gdr_info_t *info, void __user *_params)
     params.tm_cycles    = mr->tm_cycles;
     params.tsc_khz      = mr->tsc_khz;
     params.mapping_type = mr->cpu_mapping_type;
+    params.paddr        = mr->page_table->pages[0]->physical_address;
 
     gdr_put_mr_read(mr);
 

--- a/src/gdrdrv/gdrdrv.h
+++ b/src/gdrdrv/gdrdrv.h
@@ -109,6 +109,7 @@ struct GDRDRV_IOC_GET_INFO_PARAMS
     __u64 tm_cycles;
     __u32 mapped;
     __u32 wc_mapping;
+    __u64 paddr;
 };
 
 #define GDRDRV_IOC_GET_INFO _IOWR(GDRDRV_IOCTL, 4, struct GDRDRV_IOC_GET_INFO_PARAMS *)
@@ -126,6 +127,7 @@ struct GDRDRV_IOC_GET_INFO_V2_PARAMS
     __u32 tsc_khz;
     __u64 tm_cycles;
     __u32 mapping_type;
+    __u64 paddr;
 };
 
 #define GDRDRV_IOC_GET_INFO_V2 _IOWR(GDRDRV_IOCTL, 5, struct GDRDRV_IOC_GET_INFO_V2_PARAMS *)


### PR DESCRIPTION
this patch, adds the ability to retrieve the PCIE space physical Address of a GPU allocated memory region.
it turns gdrcopy into the De-Facto standard way to implement GPUDirect RDMA to 3rd party PCIE cards, leveraging the good work done elsewhere in this project, the excellent bookkeeping and the NVIDIA sponsorship