### PR TITLE
Fix compile error when use icc

### DIFF
--- a/tests/testsuites/testsuite.cpp
+++ b/tests/testsuites/testsuite.cpp
@@ -71,7 +71,7 @@ namespace gdrcopy {
 
             for (std::vector<std::string>::iterator it = tests.begin(); it != tests.end(); ++it) {
                 if ((test_map->find(*it) == test_map->end()) && (extended_test_map->find(*it) == extended_test_map->end())) {
-                    gdrcopy::test::print_dbg("Error: Encountered unknown test %s\n", *it);
+                    gdrcopy::test::print_dbg("Error: Encountered unknown test %s\n", it->c_str());
                     return EINVAL;
                 }
             }


### PR DESCRIPTION
```plain_text
/home/wukan/env-0.23.1-oneapi/spack/opt/spack/linux-ubuntu22.04-sapphirerapids/oneapi-2025.0.0/cuda-12.8.1-pe34sv2h6fxneozt3zuvz6p26aef3kyb/bin/nvcc -o pplat.o -c pplat.cu -lcuda -lpthread -ldl -lgdrapi -I /home/wukan/env-0.23.1-oneapi/spack/opt/spack/linux-ubuntu22.04-sapphirerapids/oneapi-2025.0.0/cuda-12.8.1-pe34sv2h6fxneozt3zuvz6p26aef3kyb/include -I ../include -I ../src -I /home/wukan/env-0.23.1-oneapi/spack/opt/spack/linux-ubuntu22.04-sapphirerapids/oneapi-2025.0.0/cuda-12.8.1-pe34sv2h6fxneozt3zuvz6p26aef3kyb/include  -gencode arch=compute_60,code=compute_60 -gencode arch=compute_61,code=compute_61 -gencode arch=compute_62,code=compute_62 -gencode arch=compute_70,code=compute_70 -gencode arch=compute_72,code=compute_72 -gencode arch=compute_75,code=compute_75 -gencode arch=compute_80,code=compute_80 -gencode arch=compute_86,code=compute_86 -gencode arch=compute_87,code=compute_87 -gencode arch=compute_89,code=compute_89 -gencode arch=compute_90,code=compute_90 -gencode arch=compute_100,code=compute_100 -gencode arch=compute_120,code=compute_120 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_62,code=sm_62 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_72,code=sm_72 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_87,code=sm_87 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
testsuites/testsuite.cpp:74:86: error: cannot pass object of non-trivial type 'std::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
   74 |                     gdrcopy::test::print_dbg("Error: Encountered unknown test %s\n", *it);
      |                                                                                      ^
1 error generated.
make[1]: *** [<builtin>: testsuites/testsuite.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```