### PR TITLE
fix a use-after-free in gdrdrv_get_pages_free_callback()

### DIFF
--- a/src/gdrdrv/gdrdrv.c
+++ b/src/gdrdrv/gdrdrv.c
@@ -388,6 +388,7 @@ struct gdr_mr {
     struct address_space *mapping;
     struct rw_semaphore sem;
     unsigned force_pci:1;
+    refcount_t refcnt;
 };
 typedef struct gdr_mr gdr_mr_t;
 
@@ -553,6 +554,17 @@ out:
 
 //-----------------------------------------------------------------------------
 
+static inline void get_mr(gdr_mr_t *mr)
+{
+    refcount_inc(&mr->refcnt);
+}
+
+static inline void put_mr(gdr_mr_t *mr)
+{
+    if (refcount_dec_and_test(&mr->refcnt))
+        kfree(mr);
+}
+
 /**
  * Clean up and free all resources (e.g., page_table) associated with this mr.
  *
@@ -613,7 +625,7 @@ static void gdr_free_mr_unlocked(gdr_mr_t *mr)
     }
 
     memset(mr, 0, sizeof(*mr));
-    kfree(mr);
+    put_mr(mr);
 }
 
 
@@ -751,6 +763,7 @@ static void gdrdrv_get_pages_free_callback(void *data)
     }
     mr->page_table = NULL;
     up_write(&mr->sem);
+    put_mr(mr);
 }
 
 //-----------------------------------------------------------------------------
@@ -816,6 +829,7 @@ static int __gdrdrv_pin_buffer(gdr_info_t *info, u64 addr, u64 size, u64 p2p_tok
         goto out;
     }
     memset(mr, 0, sizeof(*mr));
+    refcount_set(&mr->refcnt, 1);
 
     // do proper alignment, as required by NVIDIA driver.
     // align both size and addr as it is a requirement of nvidia_p2p_get_pages* API
@@ -826,6 +840,8 @@ static int __gdrdrv_pin_buffer(gdr_info_t *info, u64 addr, u64 size, u64 p2p_tok
     init_rwsem(&mr->sem);
 
     free_callback_fn = gdr_use_persistent_mapping() ? NULL : gdrdrv_get_pages_free_callback;
+    if (free_callback_fn)
+        get_mr(mr);
 
     get_pages_flags = 0;
     mr->offset       = addr & GPU_PAGE_OFFSET;


### PR DESCRIPTION
We met a UAF issue and caught logs by our own advanced KFENCE:

```
[215551.647409] ==================================================================
[215551.656059] BUG: KFENCE: use-after-free write in down_write+0x15/0x40

[215551.666004] Use-after-free write at 0xffff98f6bbedcfd8 (in kfence-#122733):
[215551.674368]  down_write+0x15/0x40
[215551.678638]  gdrdrv_get_pages_free_callback+0x20/0xc0 [gdrdrv]
[215551.685793]  nv_p2p_mem_info_free_callback+0x12/0x30 [nvidia]
[215551.692909]  CliDelThirdPartyP2PVidmemInfo+0x51/0x110 [nvidia]

[215551.702240] kfence-#122733: 0xffff98f6bbedcf60-0xffff98f6bbedcfff, size=160, cache=kmalloc-192

[215551.714816] allocated by task 1173198 on cpu 6 at 204393.299396s:
[215551.722240]  __gdrdrv_pin_buffer+0x59/0x4e0 [gdrdrv]
[215551.728399]  gdrdrv_pin_buffer+0x91/0x150 [gdrdrv]
[215551.734356]  gdrdrv_unlocked_ioctl+0x115/0x260 [gdrdrv]
[215551.740800]  __x64_sys_ioctl+0x88/0xc0
[215551.745579]  do_syscall_64+0x2e/0x50
[215551.750164]  entry_SYSCALL_64_after_hwframe+0x62/0xc7

[215551.758639] freed by task 1331885 on cpu 2 at 215550.913857s:
[215551.765670]  gdrdrv_release+0x9a/0x180 [gdrdrv]
[215551.771328]  __fput+0x9a/0x240
[215551.775326]  task_work_run+0x5c/0x90
[215551.779899]  do_exit+0x225/0x4d0
[215551.784079]  do_group_exit+0x33/0xa0
[215551.788638]  get_signal+0x157/0x610
[215551.793095]  arch_do_signal_or_restart+0xec/0x1d0
[215551.798980]  exit_to_user_mode_loop+0xb3/0x120
[215551.804511]  exit_to_user_mode_prepare+0x6e/0x80
[215551.810235]  syscall_exit_to_user_mode+0x12/0x40
[215551.815961]  entry_SYSCALL_64_after_hwframe+0x62/0xc7
```

`mr` is freed early by `gdr_free_mr_unlocked()`, and is use-after-free by `nvidia_p2p_put_pages()` -> `gdrdrv_get_pages_free_callback()`

Add a refcnt to fix it.