### PR TITLE
GDRCopy v2.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [master]
 
+## [2.5.2] - 2026-02-24
+- Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).
+
 ## [2.5.1] - 2025-08-04
 - Support RHEL 10.0.
 - Support CUDA 13.0.

--- a/packages/build-deb-packages.sh
+++ b/packages/build-deb-packages.sh
@@ -23,7 +23,7 @@
 # Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
 # See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 DEBIAN_VERSION=1
-PATCH_VERSION=1
+PATCH_VERSION=2
 
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."

--- a/packages/build-rpm-packages.sh
+++ b/packages/build-rpm-packages.sh
@@ -23,7 +23,7 @@
 # Restart this number at 1 if MAJOR_VERSION or MINOR_VERSION changes
 # See https://rpm-packaging-guide.github.io/#preamble-items
 RPM_VERSION=1
-PATCH_VERSION=1
+PATCH_VERSION=2
 
 SCRIPT_DIR_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 TOP_DIR_PATH="${SCRIPT_DIR_PATH}/.."

--- a/packages/debian-meta/changelog
+++ b/packages/debian-meta/changelog
@@ -2,7 +2,13 @@ gdrcopy (@FULL_VERSION@) stable; urgency=low
 
   * See CHANGELOG.md.
 
- -- GPUDirect Team <gpudirect@nvidia.com>  Mon, 04 Aug 2025 11:59:59 -0700
+ -- GPUDirect Team <gpudirect@nvidia.com>  Tue, 24 Feb 2026 10:00:00 -0700
+
+gdrcopy (2.5.2) stable; urgency=low
+
+  * Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).
+
+ -- GPUDirect Team <gpudirect@nvidia.com>  Tue, 24 Feb 2026 10:00:00 -0700
 
 gdrcopy (2.5.1) stable; urgency=low
 

--- a/packages/dkms/debian/changelog
+++ b/packages/dkms/debian/changelog
@@ -2,7 +2,13 @@ gdrdrv-dkms (@FULL_VERSION@) stable; urgency=low
 
   * See CHANGELOG.md.
 
- -- GPUDirect Team <gpudirect@nvidia.com>  Mon, 04 Aug 2025 11:59:59 -0700
+ -- GPUDirect Team <gpudirect@nvidia.com>  Tue, 24 Feb 2026 10:00:00 -0700
+
+gdrdrv-dkms (2.5.2) stable; urgency=low
+
+  * Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).
+
+ -- GPUDirect Team <gpudirect@nvidia.com>  Tue, 24 Feb 2026 10:00:00 -0700
 
 gdrdrv-dkms (2.5.1) stable; urgency=low
 

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -363,8 +363,10 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
-* Mon Aug 04 2025 GPUDirect Team <gpudirect@nvidia.com> %{GDR_VERSION}-%{_release}
+* Tue Feb 24 2025 GPUDirect Team <gpudirect@nvidia.com> %{GDR_VERSION}-%{_release}
 - See CHANGELOG.md.
+* Tue Feb 24 2025 GPUDirect Team <gpudirect@nvidia.com> 2.5.2-%{_release}
+- Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).
 * Mon Aug 04 2025 GPUDirect Team <gpudirect@nvidia.com> 2.5.1-%{_release}
 - Support RHEL 10.0.
 - Support CUDA 13.0.

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -363,7 +363,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
-* Tue Feb 24 2025 GPUDirect Team <gpudirect@nvidia.com> %{GDR_VERSION}-%{_release}
+* Tue Feb 24 2026 GPUDirect Team <gpudirect@nvidia.com> %{GDR_VERSION}-%{_release}
 - See CHANGELOG.md.
 * Tue Feb 24 2025 GPUDirect Team <gpudirect@nvidia.com> 2.5.2-%{_release}
 - Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -365,7 +365,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 %changelog
 * Tue Feb 24 2026 GPUDirect Team <gpudirect@nvidia.com> %{GDR_VERSION}-%{_release}
 - See CHANGELOG.md.
-* Tue Feb 24 2025 GPUDirect Team <gpudirect@nvidia.com> 2.5.2-%{_release}
+* Tue Feb 24 2026 GPUDirect Team <gpudirect@nvidia.com> 2.5.2-%{_release}
 - Fix build errors on recent kernels (v6.15+): mark test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).
 * Mon Aug 04 2025 GPUDirect Team <gpudirect@nvidia.com> 2.5.1-%{_release}
 - Support RHEL 10.0.

--- a/scripts/test_gdrdrv_HAVE_VM_FLAGS_SET.sh
+++ b/scripts/test_gdrdrv_HAVE_VM_FLAGS_SET.sh
@@ -56,7 +56,7 @@ static void __exit test_dummy_fini(void)
 }
 
 MODULE_AUTHOR("gpudirect@nvidia.com");
-MODULE_LICENSE("MIT");
+MODULE_LICENSE("Dual MIT/GPL");
 MODULE_VERSION("1.0");
 
 module_init(test_dummy_init);


### PR DESCRIPTION
v2.5.2 mainly contains a hotfix for issues observed on recent kernels!

Fix info: Addresses build errors on recent kernels (v6.15+); marks test-dummy.ko with Dual MIT/GPL so it may use GPL-only symbol __vma_start_write (vm_flags_set).